### PR TITLE
Change mention of roweb2 to roweb3 on archtypes

### DIFF
--- a/archetypes/Rmd/index.md
+++ b/archetypes/Rmd/index.md
@@ -38,9 +38,9 @@ Throughout this template, including the YAML,
 you should change "post-template" to the slug of your post, 
 and "2019-06-04" to your publication date.
 
-Save this file under /content/blog/YYYY-MM-DD-slug/index.Rmd in the local copy of your roweb2 fork.
+Save this file under /content/blog/YYYY-MM-DD-slug/index.Rmd in the local copy of your roweb3 fork.
 
-The chunk below ensures your plots will be inserted in the same folder as your Rmd so you can submit the bundle (.Rmd, .md, images) to roweb2.
+The chunk below ensures your plots will be inserted in the same folder as your Rmd so you can submit the bundle (.Rmd, .md, images) to roweb3.
 
 ```{r setup, include=FALSE}
 # Options to have images saved in the post folder

--- a/archetypes/md/index.md
+++ b/archetypes/md/index.md
@@ -32,7 +32,7 @@ Throughout this template, including the YAML,
 you should change "post-template" to the slug of your post, 
 and "2019-06-04" to your publication date.
 
-Save this file under /content/blog/YYYY-MM-DD-slug/index.md in the local copy of your roweb2 fork.
+Save this file under /content/blog/YYYY-MM-DD-slug/index.md in the local copy of your roweb3 fork.
 
 ## Section heading in sentence case
 


### PR DESCRIPTION
Just a minor change overlooked when moving from roweb2 to roweb3.
This PR changes the mentions of roweb2 to roweb3 on the archtypes templates of the blog.