### PR TITLE
Add 'orcid' and 'img' to maurolepore's page

### DIFF
--- a/content/author/mauro-lepore/_index.md
+++ b/content/author/mauro-lepore/_index.md
@@ -3,4 +3,6 @@ name: Mauro Lepore
 bio: Associate editor of rOpenSci Software Peer Review
 github: maurolepore
 twitter: mauro_lepore
+orcid: 0000-0002-1986-7988
+img: img/team/mauro-lepore.jpg
 ---


### PR DESCRIPTION
Relates to #52

I added my orcid and img url based on @maelle's author page:
https://raw.githubusercontent.com/ropensci/roweb3/master/content/author/ma%C3%ABlle-salmon/_index.md

This change reponds to this request by @stefaniebutland:

> Check your rOpenSci author page and request any changes (by
> reply to this email or by pull request).

--

I submit directly following what I see at https://github.com/ropensci/roweb3/pull/52, but let me know if you prefer me to close and resubmit from my fork.