### PR TITLE
Stef noreply

### DIFF
--- a/themes/ropensci/layouts/commcalls/single.ics
+++ b/themes/ropensci/layouts/commcalls/single.ics
@@ -4,7 +4,7 @@ PRODID:-//ropensci-commcalls//speaker calendar//EN
 CALSCALE:GREGORIAN
 METHOD:PUBLISH
 BEGIN:VEVENT
-ORGANIZER;CN="rOpenSci":mailto:info@ropensci.org
+ORGANIZER;CN="rOpenSci":mailto:no-reply@ropensci.org
 SUMMARY:{{.Title}} (rOpenSci comm call)
 UID:{{.Params.dateStart}}@ropensci-commcalls
 SEQUENCE:0

--- a/themes/ropensci/layouts/events/single.ics
+++ b/themes/ropensci/layouts/events/single.ics
@@ -4,7 +4,7 @@ PRODID:-//elm-conf//speaker calendar//EN
 CALSCALE:GREGORIAN
 METHOD:PUBLISH
 BEGIN:VEVENT
-ORGANIZER;CN="rOpenSci":mailto:info@ropensci.org
+ORGANIZER;CN="rOpenSci":mailto:no-reply@ropensci.org
 SUMMARY:{{.Title}} (rOpenSci)
 UID:{{.Params.dateStart}}@ropensci-commcalls
 SEQUENCE:0


### PR DESCRIPTION
add mailto:no-reply@ropensci.org to replace mailto:info@ropensci.org so we don't get email when someone adds community call to their calendar