### PR TITLE
Add twitter:image:alt in Twitter cards

### DIFF
--- a/archetypes/Rmd/index.md
+++ b/archetypes/Rmd/index.md
@@ -19,11 +19,12 @@ tags:
 # The summary below will be used by e.g. Twitter cards
 description: "A very short summary of your post (~ 100 characters)"
 # If you have no preferred image for Twitter cards,
-# delete the twitterImg line below 
+# delete the twitterImg and twitterAlt lines below 
 # - Replace "blog" with "technotes" as needed
 # - Note no "/" symbol before "blog" here
 # - Note "/" between year/month/day
 twitterImg: blog/2019/06/04/post-template/name-of-image.png
+twitterAlt: "Alternative description of the image"
 # 'output' is necessary to obtain index.md
 # Do not commit index.html
 output: 

--- a/archetypes/md/index.md
+++ b/archetypes/md/index.md
@@ -19,10 +19,11 @@ tags:
 # The summary below will be used by e.g. Twitter cards
 description: "A very short summary of your post (~ 100 characters)"
 # If you have no preferred image for Twitter cards,
-# delete the twitterImg line below 
+# delete the twitterImg and twitterAlt lines below 
 # - Replace "blog" with "technotes" as needed
 # - Note "/" between year/month/day
 twitterImg: blog/2019/06/04/post-template/name-of-image.png
+twitterAlt: "Alternative description of the image"
 ---
 
 This is the Markdown (.md) template for a blog post or tech note. 

--- a/content/blog/2020-09-29-mapscanner/index.md
+++ b/content/blog/2020-09-29-mapscanner/index.md
@@ -24,6 +24,7 @@ description: "The mapscanner package enables lines drawn by hand on maps to be c
 # Note there is no '/' symbol before 'img' here
 # if needed replace blog with technotes
 twitterImg: blog/2020/09/29/mapscanner/poly-aggr-plot.png
+twitterAlt: "Polygons aggregated with mapscanner::ms_aggregate_polys()"
 ---
 
 ## mapscanner

--- a/themes/ropensci/layouts/partials/skeleton/head.html
+++ b/themes/ropensci/layouts/partials/skeleton/head.html
@@ -60,6 +60,9 @@
   {{ if .Params.twitterImg }}
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="{{ .Params.twitterImg | absURL }}" >
+    {{ with .Params.twitterAlt }}
+    <meta name="twitter:image:alt" content="{{ . }}">
+    {{ end }}
   {{ else }}
     <meta name="twitter:card" content="summary">
     <meta name="twitter:image" content="{{ "android-chrome-512x512.png"  | absURL }}" >


### PR DESCRIPTION
Fix #8 

Cf https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image

@ropensci/blog-editors if you approve this I'll also make a PR in the blog guide.