### PR TITLE
add tags to editors posts

### DIFF
--- a/content/blog/2020-10-27-editors2020/index.md
+++ b/content/blog/2020-10-27-editors2020/index.md
@@ -6,6 +6,7 @@ slug: editors2020
 tags:
   - Software Peer Review
   - editors
+  - rOpenSci team
 description: Introducing 3 new editors for rOpenSci software review
 # twitterImg: blog/2019/06/04/post-template/name-of-image.png
 ---


### PR DESCRIPTION
use tags `editors` and `rOpenSci team`. previously tags were used inconsistently