### PR TITLE
more calendar instructions

### DIFF
--- a/themes/ropensci/layouts/partials/calendar/events.html
+++ b/themes/ropensci/layouts/partials/calendar/events.html
@@ -16,7 +16,7 @@
     <div class="row justify-content-center">
     <div class="col-md-8">
         <p class="subtitle"><i>
-          You can subscribe to rOpenSci-lead events via <a href="/events/index.ics">our ICS calendar</a> (copy the link, add it to your calendar service e.g. <a href="https://support.mozilla.org/en-US/kb/creating-new-calendars#w_on-the-network-connect-to-your-online-calendars">Thunderbird</a> or Google Calendar). Please note that if you use Google Calendar you have to <a href="https://calendar.google.com/calendar/u/0/syncselect">check synchronization is turned on</a>; furthermore, synchronization might be delayed.</i>
+          You can subscribe to rOpenSci-led events via <a href="/events/index.ics">our ICS calendar</a> (copy the link, add it to your calendar service e.g. <a href="https://support.mozilla.org/en-US/kb/creating-new-calendars#w_on-the-network-connect-to-your-online-calendars">Thunderbird</a> or Google Calendar). If you use Google Calendar, <a href="https://calendar.google.com/calendar/u/0/syncselect">check that synchronization is turned on</a> and note that synchronization might be delayed. When <em>opening</em> .ics files on OSX, you might need to <a href="https://apple.stackexchange.com/questions/3509/can-i-set-os-x-to-automatically-open-ics-files-in-ical">change settings</a>.</i>
         </p>
         <p class="subtitle"><i>
           When <em>opening</em> .ics files on OSX, you might need to <a href="https://apple.stackexchange.com/questions/3509/can-i-set-os-x-to-automatically-open-ics-files-in-ical">change settings</a>.

--- a/themes/ropensci/layouts/partials/calendar/events.html
+++ b/themes/ropensci/layouts/partials/calendar/events.html
@@ -7,21 +7,13 @@
     {{ if gt (len $pages) 0 }}
         <p class="subtitle">
           Upcoming events including Community Calls and meetings at which our team members are speaking.</p>
+        <p class="subtitle"><i>
+          You can subscribe to rOpenSci-led events via <a href="/events/index.ics">our ICS calendar</a> (copy the link, add it to your calendar service e.g. <a href="https://support.mozilla.org/en-US/kb/creating-new-calendars#w_on-the-network-connect-to-your-online-calendars">Thunderbird</a> or Google Calendar). If you use Google Calendar, <a href="https://calendar.google.com/calendar/u/0/syncselect">check that synchronization is turned on</a> and note that synchronization might be delayed. When <em>opening</em> .ics files on OSX, you might need to <a href="https://apple.stackexchange.com/questions/3509/can-i-set-os-x-to-automatically-open-ics-files-in-ical">change settings</a>.</i>
+        </p>
       </div>
     </div>
     {{ partial "calendar/calendar" (dict "Site" .Site) }}
     {{ else }}
     <p class="subtitle">No event scheduled at the moment</p>
     {{ end}}
-    <div class="row justify-content-center">
-    <div class="col-md-8">
-        <p class="subtitle"><i>
-          You can subscribe to rOpenSci-led events via <a href="/events/index.ics">our ICS calendar</a> (copy the link, add it to your calendar service e.g. <a href="https://support.mozilla.org/en-US/kb/creating-new-calendars#w_on-the-network-connect-to-your-online-calendars">Thunderbird</a> or Google Calendar). If you use Google Calendar, <a href="https://calendar.google.com/calendar/u/0/syncselect">check that synchronization is turned on</a> and note that synchronization might be delayed. When <em>opening</em> .ics files on OSX, you might need to <a href="https://apple.stackexchange.com/questions/3509/can-i-set-os-x-to-automatically-open-ics-files-in-ical">change settings</a>.</i>
-        </p>
-        <p class="subtitle"><i>
-          When <em>opening</em> .ics files on OSX, you might need to <a href="https://apple.stackexchange.com/questions/3509/can-i-set-os-x-to-automatically-open-ics-files-in-ical">change settings</a>.
-        </p>
-        </div>
-        </div>
-  </div>
 </section>

--- a/themes/ropensci/layouts/partials/calendar/events.html
+++ b/themes/ropensci/layouts/partials/calendar/events.html
@@ -7,14 +7,21 @@
     {{ if gt (len $pages) 0 }}
         <p class="subtitle">
           Upcoming events including Community Calls and meetings at which our team members are speaking.</p>
-        <p class="subtitle"><i>
-          You can subscribe to rOpenSci-lead events via <a href="/events/index.ics">our ICS calendar</a> (copy the link, add it to your calendar service e.g. <a href="https://support.mozilla.org/en-US/kb/creating-new-calendars#w_on-the-network-connect-to-your-online-calendars">Thunderbird</a> or Google Calendar). Please note that if you use Google Calendar you have to <a href="https://calendar.google.com/calendar/u/0/syncselect">check synchronization is turned on</a>; furthermore, synchronization might be delayed.</i>
-        </p>
       </div>
     </div>
     {{ partial "calendar/calendar" (dict "Site" .Site) }}
     {{ else }}
     <p class="subtitle">No event scheduled at the moment</p>
     {{ end}}
+    <div class="row justify-content-center">
+    <div class="col-md-8">
+        <p class="subtitle"><i>
+          You can subscribe to rOpenSci-lead events via <a href="/events/index.ics">our ICS calendar</a> (copy the link, add it to your calendar service e.g. <a href="https://support.mozilla.org/en-US/kb/creating-new-calendars#w_on-the-network-connect-to-your-online-calendars">Thunderbird</a> or Google Calendar). Please note that if you use Google Calendar you have to <a href="https://calendar.google.com/calendar/u/0/syncselect">check synchronization is turned on</a>; furthermore, synchronization might be delayed.</i>
+        </p>
+        <p class="subtitle"><i>
+          When <em>opening</em> .ics files on OSX, you might need to <a href="https://apple.stackexchange.com/questions/3509/can-i-set-os-x-to-automatically-open-ics-files-in-ical">change settings</a>.
+        </p>
+        </div>
+        </div>
   </div>
 </section>


### PR DESCRIPTION
Fix #263

I moved the instructions to below the events so it is less a problem to make them longer. Does this work?