### PR TITLE
add Zoom URL to events ICS

### DIFF
--- a/themes/ropensci/layouts/commcalls/single.ics
+++ b/themes/ropensci/layouts/commcalls/single.ics
@@ -12,7 +12,7 @@ STATUS:CONFIRMED
 DTSTAMP:{{dateFormat "20060102T150405Z" .Params.dateStart}}
 DTSTART;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateStart}}
 DTEND;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateEnd}}
-LOCATION:{{ if isset .Params "zoomurl" }}.Params.zoomurl{{ else }}See URL{{ end }}
+LOCATION:{{ if isset .Params "zoomurl" }}{{ .Params.zoomurl }}{{ else }}See URL{{ end }}
 DESCRIPTION:{{ with .Params.description}}{{ . }}{{ end }} {{.Permalink}}
 URL:{{.Permalink}}
 END:VEVENT

--- a/themes/ropensci/layouts/commcalls/single.ics
+++ b/themes/ropensci/layouts/commcalls/single.ics
@@ -12,7 +12,7 @@ STATUS:CONFIRMED
 DTSTAMP:{{dateFormat "20060102T150405Z" .Params.dateStart}}
 DTSTART;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateStart}}
 DTEND;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateEnd}}
-LOCATION:Online
+LOCATION:{{ if isset .Params "zoomurl" }}.Params.zoomurl{{ else }}See URL{{ end }}
 DESCRIPTION:{{ with .Params.description}}{{ . }}{{ end }} {{.Permalink}}
 URL:{{.Permalink}}
 END:VEVENT

--- a/themes/ropensci/layouts/events/list.ics
+++ b/themes/ropensci/layouts/events/list.ics
@@ -12,7 +12,7 @@ STATUS:CONFIRMED
 DTSTAMP:{{dateFormat "20060102T150405Z" .Params.dateStart}}
 DTSTART;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateStart}}
 DTEND;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateEnd}}
-LOCATION:Online
+LOCATION:{{ if isset .Params "zoomurl" }}{{ .Params.zoomurl }}{{ else }}See URL{{ end }}
 DESCRIPTION:{{.Permalink}}
 URL:{{.Permalink}}
 END:VEVENT{{ end }}{{ end }}

--- a/themes/ropensci/layouts/events/single.ics
+++ b/themes/ropensci/layouts/events/single.ics
@@ -12,7 +12,7 @@ STATUS:CONFIRMED
 DTSTAMP:{{dateFormat "20060102T150405Z" .Params.dateStart}}
 DTSTART;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateStart}}
 DTEND;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateEnd}}
-LOCATION:Online
+LOCATION:{{ if isset .Params "zoomurl" }}.Params.zoomurl{{ else }}See URL{{ end }}
 DESCRIPTION:{{ with .Params.description}}{{ . }}{{ end }}{{.Permalink}}
 URL:{{.Permalink}}
 END:VEVENT

--- a/themes/ropensci/layouts/events/single.ics
+++ b/themes/ropensci/layouts/events/single.ics
@@ -12,8 +12,8 @@ STATUS:CONFIRMED
 DTSTAMP:{{dateFormat "20060102T150405Z" .Params.dateStart}}
 DTSTART;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateStart}}
 DTEND;TZID=Etc/UTC:{{dateFormat "20060102T150405" .Params.dateEnd}}
-LOCATION:{{ if isset .Params "zoomurl" }}.Params.zoomurl{{ else }}See URL{{ end }}
-DESCRIPTION:{{ with .Params.description}}{{ . }}{{ end }}{{.Permalink}}
+LOCATION:{{ if isset .Params "zoomurl" }}{{ .Params.zoomurl }}{{ else }}See URL{{ end }}
+DESCRIPTION:{{ with .Params.description}}{{ . }}{{ end }} {{.Permalink}}
 URL:{{.Permalink}}
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
Fix #288 (excellent point, it's true that the current setup assumed a few more clicks to get the Zoom URL via the event description!).

@stefaniebutland it works for me but I'd be grateful for a review.
Ideally test it on two events 
- one with a zoom URL (co-working)
- one without it (Jeroen's NHS-R talk)
And on one comm call.

I am a bit worried the ics files might have info truncated depended on where they're added. Do we know what software Dan Katz used for their calendar?