### PR TITLE
Add coworking events until June 2022

### DIFF
--- a/content/events/2022-01-04-coworking-2022-01.md
+++ b/content/events/2022-01-04-coworking-2022-01.md
@@ -21,7 +21,7 @@ deets: |
 zoomurl: https://zoom.us/j/91633835045?pwd=MkkvOUVHQU84TEhTOVpaYU1KYU5Xdz09    
 ---
 
-**Join us for 2 hours Tuesday, January 4th, 9 AM Pacific / 16:00 UTC for Social Coworking + Office Hours.**
+**Join us for 2 hours Tuesday, January 4th, 9 AM North American Pacific / 16:00 UTC for Social Coworking + Office Hours.**
 
 We are hosting [Social Coworking + Office Hours](/blog/2021/08/17/coworking-sessions/) on the first Tuesday of each month, alternating times to accommodate different parts of the world.
 

--- a/content/events/2022-02-01-coworking-2022-02.md
+++ b/content/events/2022-02-01-coworking-2022-02.md
@@ -13,7 +13,7 @@ outputs:
 - Calendar 
 attendees:
   - Nicholas Tierney
-  - Stefanie Butland
+  - Steffi LaZerte
 deets: |
     Meeting ID: 916 3383 5045
     

--- a/content/events/2022-03-01-coworking-2022-03.md
+++ b/content/events/2022-03-01-coworking-2022-03.md
@@ -28,7 +28,7 @@ lubridate::with_tz(d, "UTC")
 ```
 -->
 
-**Join us for 2 hours Tuesday, March 1st, 9 AM Pacific / 17:00 UTC for Social Coworking + Office Hours.**
+**Join us for 2 hours Tuesday, March 1st, 9 AM North American Pacific / 17:00 UTC for Social Coworking + Office Hours.**
 
 We are hosting [Social Coworking + Office Hours](/blog/2021/08/17/coworking-sessions/) on the first Tuesday of each month, alternating times to accommodate different parts of the world.
 

--- a/content/events/2022-03-01-coworking-2022-03.md
+++ b/content/events/2022-03-01-coworking-2022-03.md
@@ -1,0 +1,47 @@
+---
+title: Social Coworking and Office Hours
+dateStart: 2022-03-01T17:00:00 # UTC!!
+dateEnd: 2022-03-01T19:00:00 # UTC!!
+date: 2022-03-01T19:00:00 # UTC!! same as dateEnd
+description: Monthly coworking for productivity, asking questions, socializing
+location: 'online' # free text
+slug: "coworking-2022-03"
+country: "\U0001F310" # emoji
+ropensci: yes
+outputs: 
+- HTML
+- Calendar 
+attendees:
+  - Steffi LaZerte
+  - Stefanie Butland
+deets: |
+    Meeting ID: 916 3383 5045
+    
+    Passcode: 253788
+zoomurl: https://zoom.us/j/91633835045?pwd=MkkvOUVHQU84TEhTOVpaYU1KYU5Xdz09    
+---
+
+<!--
+```{r}
+d <- lubridate::ymd_hms("2022-03-01 09:00:00", tz = "America/Vancouver")
+lubridate::with_tz(d, "UTC")
+```
+-->
+
+**Join us for 2 hours Tuesday, March 1st, 9 AM Pacific / 17:00 UTC for Social Coworking + Office Hours.**
+
+We are hosting [Social Coworking + Office Hours](/blog/2021/08/17/coworking-sessions/) on the first Tuesday of each month, alternating times to accommodate different parts of the world.
+
+Come for the full 2 hrs or only as long as you need!
+
+- Meet other package developers and rOpenSci staff in Zoom
+- Cowork independently on work related to R
+  - Plan out that package you've always wanted to create
+  - Work on packages that tend to be neglected
+  - Make your packages more [contributor-friendly](/blog/2021/04/28/commcall-pkg-community/) (create issues, write a road map, etc.)
+  - What ever you need to get done!
+- Get answers to your questions
+  - Ask rOpenSci staff
+  - Ask your fellow developers
+  - Discuss your work, best practices, or get advice and resources
+- Answer other developers questions!

--- a/content/events/2022-04-05-coworking-2022-04.md
+++ b/content/events/2022-04-05-coworking-2022-04.md
@@ -1,0 +1,49 @@
+---
+title: Social Coworking and Office Hours
+dateStart: 2022-04-05T01:00:00 # UTC!!
+dateEnd: 2022-04-05T03:00:00 # UTC!!
+date: 2022-04-05T03:00:00 # UTC!! same as dateEnd
+description: Monthly coworking for productivity, asking questions, socializing
+location: 'online' # free text
+slug: "coworking-2022-04"
+country: "\U0001F310" # emoji
+ropensci: yes
+outputs: 
+- HTML
+- Calendar 
+attendees:
+  - Nicholas Tierney
+  - Stefanie Butland
+deets: |
+    Meeting ID: 916 3383 5045
+    
+    Passcode: 253788
+zoomurl: https://zoom.us/j/91633835045?pwd=MkkvOUVHQU84TEhTOVpaYU1KYU5Xdz09    
+---
+
+<!--
+```{r}
+d <- lubridate::ymd_hms("2022-04-05 09:00:00", tz = "Australia/Perth")
+lubridate::with_tz(d, "UTC")
+lubridate::with_tz(d, "America/Winnipeg")
+lubridate::with_tz(d, "America/Vancouver")
+```
+-->
+
+**Join us for 2 hours Tuesday, April 5th, 9 AM Australian Western / 1:00 UTC for Social Coworking + Office Hours.**
+
+We are hosting [Social Coworking + Office Hours](/blog/2021/08/17/coworking-sessions/) on the first Tuesday of each month, alternating times to accommodate different parts of the world. 
+
+Come for the full 2 hrs or only as long as you need!
+
+- Meet other package developers and rOpenSci staff in Zoom
+- Cowork independently on work related to R
+  - Plan out that package you've always wanted to create
+  - Work on packages that tend to be neglected
+  - Make your packages more [contributor-friendly](/blog/2021/04/28/commcall-pkg-community/) (create issues, write a road map, etc.)
+  - What ever you need to get done!
+- Get answers to your questions
+  - Ask rOpenSci staff
+  - Ask your fellow developers
+  - Discuss your work, best practices, or get advice and resources
+- Answer other developers questions!

--- a/content/events/2022-04-05-coworking-2022-04.md
+++ b/content/events/2022-04-05-coworking-2022-04.md
@@ -13,7 +13,7 @@ outputs:
 - Calendar 
 attendees:
   - Nicholas Tierney
-  - Stefanie Butland
+  - Steffi LaZerte
 deets: |
     Meeting ID: 916 3383 5045
     

--- a/content/events/2022-05-03-coworking-2022-05.md
+++ b/content/events/2022-05-03-coworking-2022-05.md
@@ -28,7 +28,7 @@ lubridate::with_tz(d, "UTC")
 ```
 -->
 
-**Join us for 2 hours Tuesday, May 3rd, 9 AM Pacific / 16:00 UTC for Social Coworking + Office Hours.**
+**Join us for 2 hours Tuesday, May 3rd, 9 AM North American Pacific / 16:00 UTC for Social Coworking + Office Hours.**
 
 We are hosting [Social Coworking + Office Hours](/blog/2021/08/17/coworking-sessions/) on the first Tuesday of each month, alternating times to accommodate different parts of the world.
 

--- a/content/events/2022-05-03-coworking-2022-05.md
+++ b/content/events/2022-05-03-coworking-2022-05.md
@@ -1,0 +1,47 @@
+---
+title: Social Coworking and Office Hours
+dateStart: 2022-05-03T16:00:00 # UTC!!
+dateEnd: 2022-05-03T18:00:00 # UTC!!
+date: 2022-05-03T18:00:00 # UTC!! same as dateEnd
+description: Monthly coworking for productivity, asking questions, socializing
+location: 'online' # free text
+slug: "coworking-2022-05"
+country: "\U0001F310" # emoji
+ropensci: yes
+outputs: 
+- HTML
+- Calendar 
+attendees:
+  - Steffi LaZerte
+  - Stefanie Butland
+deets: |
+    Meeting ID: 916 3383 5045
+    
+    Passcode: 253788
+zoomurl: https://zoom.us/j/91633835045?pwd=MkkvOUVHQU84TEhTOVpaYU1KYU5Xdz09    
+---
+
+<!--
+```{r}
+d <- lubridate::ymd_hms("2022-05-03 09:00:00", tz = "America/Vancouver")
+lubridate::with_tz(d, "UTC")
+```
+-->
+
+**Join us for 2 hours Tuesday, May 3rd, 9 AM Pacific / 16:00 UTC for Social Coworking + Office Hours.**
+
+We are hosting [Social Coworking + Office Hours](/blog/2021/08/17/coworking-sessions/) on the first Tuesday of each month, alternating times to accommodate different parts of the world.
+
+Come for the full 2 hrs or only as long as you need!
+
+- Meet other package developers and rOpenSci staff in Zoom
+- Cowork independently on work related to R
+  - Plan out that package you've always wanted to create
+  - Work on packages that tend to be neglected
+  - Make your packages more [contributor-friendly](/blog/2021/04/28/commcall-pkg-community/) (create issues, write a road map, etc.)
+  - What ever you need to get done!
+- Get answers to your questions
+  - Ask rOpenSci staff
+  - Ask your fellow developers
+  - Discuss your work, best practices, or get advice and resources
+- Answer other developers questions!

--- a/content/events/2022-06-07-coworking-2022-06.md
+++ b/content/events/2022-06-07-coworking-2022-06.md
@@ -1,0 +1,49 @@
+---
+title: Social Coworking and Office Hours
+dateStart: 2022-06-07T01:00:00 # UTC!!
+dateEnd: 2022-06-07T03:00:00 # UTC!!
+date: 2022-06-07T03:00:00 # UTC!! same as dateEnd
+description: Monthly coworking for productivity, asking questions, socializing
+location: 'online' # free text
+slug: "coworking-2022-06"
+country: "\U0001F310" # emoji
+ropensci: yes
+outputs: 
+- HTML
+- Calendar 
+attendees:
+  - Nicholas Tierney
+  - Stefanie Butland
+deets: |
+    Meeting ID: 916 3383 5045
+    
+    Passcode: 253788
+zoomurl: https://zoom.us/j/91633835045?pwd=MkkvOUVHQU84TEhTOVpaYU1KYU5Xdz09    
+---
+
+<!--
+```{r}
+d <- lubridate::ymd_hms("2022-06-07 09:00:00", tz = "Australia/Perth")
+lubridate::with_tz(d, "UTC")
+lubridate::with_tz(d, "America/Winnipeg")
+lubridate::with_tz(d, "America/Vancouver")
+```
+-->
+
+**Join us for 2 hours Tuesday, June 7th, 9 AM Australian Western / 1:00 UTC for Social Coworking + Office Hours.**
+
+We are hosting [Social Coworking + Office Hours](/blog/2021/08/17/coworking-sessions/) on the first Tuesday of each month, alternating times to accommodate different parts of the world. 
+
+Come for the full 2 hrs or only as long as you need!
+
+- Meet other package developers and rOpenSci staff in Zoom
+- Cowork independently on work related to R
+  - Plan out that package you've always wanted to create
+  - Work on packages that tend to be neglected
+  - Make your packages more [contributor-friendly](/blog/2021/04/28/commcall-pkg-community/) (create issues, write a road map, etc.)
+  - What ever you need to get done!
+- Get answers to your questions
+  - Ask rOpenSci staff
+  - Ask your fellow developers
+  - Discuss your work, best practices, or get advice and resources
+- Answer other developers questions!


### PR DESCRIPTION
Added the coworking events for March, April, May and June.

Stef, I've got you as a reviewer for a sanity check of the dates and timezones! I've included a hidden bit of R code to give me a hand in double checking the dates (with timezone changes etc.) and maybe next time I'll write out a script for creating the event entirely (we'll see, it's not really that time consuming!). 

