### PR TITLE
placeholder and links to COC in Spanish

### DIFF
--- a/content/codigo-de-conducta.md
+++ b/content/codigo-de-conducta.md
@@ -1,10 +1,10 @@
 +++
-title = "Code of Conduct (English version)"
-description = "rOpenSci Code of Conduct"
+title = "Codigo de Conducta (versión en español)"
+description = "Codigo de Conducta de rOpenSci"
 subtitle = "Version 2.3 – January 13, 2022"
 +++
 
-_El codigo de conducta también esta disponible en [español](/codigo-de-conducta)._
+_The Code of Conduct is also available in [English](/code-of-conduct)._
 
 rOpenSci's community is our best asset and we believe that our diversity is our strength. We are building a welcoming and diverse global community of software users and developers from a range of research domains. It's so important to us, it's in [our mission statement](/about/). Whether you’re a regular contributor or a newcomer, we care about making this a safe place for you and we’ve got your back.
 

--- a/themes/ropensci/layouts/partials/skeleton/footer.html
+++ b/themes/ropensci/layouts/partials/skeleton/footer.html
@@ -20,7 +20,8 @@
             <li><a class="footer-nav__link" href="/commcalls/">Community Calls</a></li>
             <li><a class="footer-nav__link" href="/events/">Events</a></li>
             <li><a class="footer-nav__link external-link" href="https://discuss.ropensci.org/">Join the Discussion</a></li>
-            <li><a class="footer-nav__link" href="/code-of-conduct/">Code of Conduct</a></li>
+            <li><a class="footer-nav__link" href="/code-of-conduct/">Code of Conduct (EN)</a></li>
+            <li><a class="footer-nav__link" href="/code-of-conduct/">Codigo de Conducta (ES)</a></li>
           </ul>
           <ul class="footer-nav__item">
             <li><a class="footer-nav__link" href="/resources/">Resources</a></li>

--- a/themes/ropensci/layouts/partials/skeleton/navbar.html
+++ b/themes/ropensci/layouts/partials/skeleton/navbar.html
@@ -71,7 +71,8 @@
           <ul class="sub-menu">
             <li><a href="/commcalls/">Community Calls</a></li>
             <li><a href="/events/">Events</a></li>
-            <li><a href="/code-of-conduct/">Code of Conduct</a></li>
+            <li><a href="/code-of-conduct/">Code of Conduct (EN)</a></li>
+            <li><a href="/code-of-conduct/">Codigo de Conducta (ES)</a></li>
             <li><a href="https://contributing.ropensci.org/" class="external-link">Contributing Guide</a></li>
             <li><a href="https://discuss.ropensci.org/" class="external-link">Forum</a></li>
           </ul>


### PR DESCRIPTION
Fix #357 

TODOS

- [ ] Add actual text in Spanish once it's ready

Notes on what the PR contains
- I added a link to the COC in Spanish in the navbar and in the footer. I added "(EN)" and "(ES)" for more clarity.
- Each of the COC versions links to the other one.

Happy to tweak based on feedback :smile_cat: 