### PR TITLE
new stats badges

### DIFF
--- a/content/author/joel-nitta/_index.md
+++ b/content/author/joel-nitta/_index.md
@@ -1,6 +1,0 @@
----
-name: Joel Nitta
-link: https://www.joelnitta.com/
-github: joelnitta
-twitter: joel_nitta
----

--- a/content/author/joel-nitta/_index.md
+++ b/content/author/joel-nitta/_index.md
@@ -1,0 +1,6 @@
+---
+name: Joel Nitta
+link: https://www.joelnitta.com/
+github: joelnitta
+twitter: joel_nitta
+---

--- a/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
+++ b/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
@@ -65,7 +65,7 @@ We are overjoyed to have the first package pass through our Statistical Software
 Among many exciting aspects of the expansion of software peer review to statistical software is the introduction of new statistics-specific "Peer Reviewed" badges.
 Until now, every rOpenSci package has used the same single badge. Our new badges for statistical packages include a "grade" of [bronze, silver, or gold](https://stats-devguide.ropensci.org/pkgdev.html#pkgdev-badges), and the version number of the [*Statistical Software Standards*](https://stats-devguide.ropensci.org/standards.html) with which a package complies.
 You can see the first statistical software badge on the front page of [Joel's canaper repository](https://github.com/ropensci/canaper#canaper), with a "silver" grade for compliance with version 0.1 of our statistical standards.
-There are already quite a number of other statistical packages under review, and we'll be excited to see many more of these new badges appearing on rOpenSci packages soon.
+There are already a number of other [statistical packages under review](https://github.com/ropensci/software-review/issues?q=is%3Aissue+label%3Astats+is%3Aopen), and we'll be excited to see many more of these new badges appearing on rOpenSci packages soon.
 
 
 ### Coworking sessions continue!

--- a/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
+++ b/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
@@ -61,7 +61,7 @@ Thank you!
 ### New "Peer Reviewed" badges for Statistical Software Review
 
 We are overjoyed to have the first package pass through our Statistical Software Review process.
-[The canaper package](https://github.com/ropensci/canaper) by [Joel NItta](/author/joel-nitta/) was [approved on the 14th of Sept. 2022](https://github.com/ropensci/software-review/issues/475#issuecomment-1247094903).
+[The canaper package](https://docs.ropensci.org/canaper/) by [Joel Nitta](https://www.joelnitta.com/) was [approved on the 14th of September 2022](https://github.com/ropensci/software-review/issues/475#issuecomment-1247094903).
 Among many exciting aspects of the expansion of software peer review to statistical software is the introduction of new statistics-specific "Peer Reviewed" badges.
 Until now, every rOpenSci package has used the same single badge. Our new badges for statistical packages include a "grade" of [bronze, silver, or gold](https://stats-devguide.ropensci.org/pkgdev.html#pkgdev-badges), and the version number of the [*Statistical Software Standards*](https://stats-devguide.ropensci.org/standards.html) with which a package complies.
 You can see the first statistical software badge on the front page of [Joel's canaper repository](https://github.com/ropensci/canaper#canaper), with a "silver" grade for compliance with version 0.1 of our statistical standards.

--- a/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
+++ b/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
@@ -66,6 +66,10 @@ Consult our [Events](/events) page to find your local time and how to join.
 
 Find out about more [events](/events).
 
+### pkgcheck updates
+
+Our [pkgcheck checks](https://docs.ropensci.org/pkgcheck) now have an additional category beyond just pass (:heavy_check_mark:) or fail (:heavy_multiplication_x:). Some checks indicate aspects which are worth considering, but which might not necessarily be considered check failures. We have introduced the symbol :eyes: to denote aspects of packages which authors might consider modifying or tweaking at their discretion, but which do not indicate failing checks. The only check in this category at present is the check for duplicated function names, but other :eyes: checks are likely to be included as our automated check system expands its scope in the future.
+
 ## Software :package:
 
 ### New packages

--- a/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
+++ b/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
@@ -58,6 +58,16 @@ You could volunteer on your own or as a team of maintainers (the more the merrie
 The rOpenSci team will be happy to help you with specifics, and will provide resources, tips and PR reviews as needed.
 Thank you!
 
+### New "Peer Reviewed" badges for Statistical Software Review
+
+We are thrilled to have the first package pass through our Statistical Software Review process.
+[The canaper package](https://github.com/ropensci/canaper) by [Joel NItta](/author/joel-nitta/) was [approved on the 14th of Sept. 2022](https://github.com/ropensci/software-review/issues/475#issuecomment-1247094903).
+Among many exciting aspects of the expansion of software peer review to statistical software is the introduction of new statistics-specific "Peer Reviewed" badges.
+Until now, every rOpenSci package has used the same single badge. Our new badges for statistical packages include a "grade" of [bronze, silver, or gold](https://stats-devguide.ropensci.org/pkgdev.html#pkgdev-badges), and the version number of the [*Statistical Software Standards*](https://stats-devguide.ropensci.org/standards.html) with which a package complies.
+You can see the first statistical software badge on the front page of [Joel's canaper repository](https://github.com/ropensci/canaper#canaper), with a "silver" grade for compliance with version 0.1 of our statistical standards.
+There are already quite a number of other statistical packages under review, and we'll be excited to see many more of these new badges appearing on rOpenSci packages soon.
+
+
 ### Coworking sessions continue!
 
 Join us for social coworking & office hours monthly on first Tuesdays! 

--- a/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
+++ b/content/blog/2022-09-23-ropensci-news-digest-september-2022/index.Rmd
@@ -60,7 +60,7 @@ Thank you!
 
 ### New "Peer Reviewed" badges for Statistical Software Review
 
-We are thrilled to have the first package pass through our Statistical Software Review process.
+We are overjoyed to have the first package pass through our Statistical Software Review process.
 [The canaper package](https://github.com/ropensci/canaper) by [Joel NItta](/author/joel-nitta/) was [approved on the 14th of Sept. 2022](https://github.com/ropensci/software-review/issues/475#issuecomment-1247094903).
 Among many exciting aspects of the expansion of software peer review to statistical software is the introduction of new statistics-specific "Peer Reviewed" badges.
 Until now, every rOpenSci package has used the same single badge. Our new badges for statistical packages include a "grade" of [bronze, silver, or gold](https://stats-devguide.ropensci.org/pkgdev.html#pkgdev-badges), and the version number of the [*Statistical Software Standards*](https://stats-devguide.ropensci.org/standards.html) with which a package complies.


### PR DESCRIPTION
@joelnitta This is the announcment of your package and our new badges. ~~It includes an "author" file for you. I can't assign you as a reviewer here, but please add any additional information you like to your author file. Have a look at others for typical fields, which commonly include a one-line bio, and an ORCID id, and add any of those if you want. The author files link directly to internal pages, like [my one here](https://ropensci.org/author/mark-padgham/). Yours will be an initial placeholder, but with external links to the fields in your author file.~~

Update: Sorry Joel, author files only get started when you have your first internal page on the main website, such as a blog post. Link updated to your personal website instead.