### PR TITLE
add rel="me" to mastodon links

### DIFF
--- a/themes/ropensci/layouts/author/list.html
+++ b/themes/ropensci/layouts/author/list.html
@@ -18,7 +18,7 @@
          {{ with .Params.link }}<a href="{{ . }}"><i class="fas fa-home"></i></a>{{ end }}
          {{ with .Params.orcid }}<a href="https://orcid.org/{{ . }}"><i class="fab fa-orcid"></i></a>{{ end }}
            {{ with .Params.twitter }}<a href="https://twitter.com/{{ . }}"> <i class="fab fa-twitter"></i></a>{{ end }}
-         {{ with .Params.mastodon }}<a href="{{ . }}"><i class="fab fa-mastodon"></i></a>{{ end }}
+         {{ with .Params.mastodon }}<a rel="me" href="{{ . }}"><i class="fab fa-mastodon"></i></a>{{ end }}
           {{ with .Params.github }}<a href="https://github.com/{{ . }}"> <i class="fab fa-github"></i></a>{{ end }}
          {{ with .Params.gitlab }}<a href="https://gitlab.com/{{ . }}"><i class="fab fa-gitlab"></i></a>{{ end }}
          {{ with .Params.keybase }}<a href="https://keybase.io/{{ . }}"><i class="fab fa-keybase"></i></a>{{ end }}

--- a/themes/ropensci/layouts/partials/whole-page-fragments/team/team-member.html
+++ b/themes/ropensci/layouts/partials/whole-page-fragments/team/team-member.html
@@ -23,7 +23,7 @@
         {{ end }}
         <div class="user-social d-flex">
           {{ with .twitter }}<a href="https://twitter.com/{{ . }}"><img src="/images/users/twitter.svg" alt="" /></a>{{ end }}
-          {{ with .mastodon }}<a href="{{ . }}"><img src="/images/users/mastodon.svg" alt="" style="max-width:16px;max-height:16px;"/></a>{{ end }}
+          {{ with .mastodon }}<a rel="me" href="{{ . }}"><img src="/images/users/mastodon.svg" alt="" style="max-width:16px;max-height:16px;"/></a>{{ end }}
           {{ with .github }}<a href="https://github.com/{{ . }}"><img src="/images/users/github.svg" alt="" /></a>{{ end }}
          {{ with .home }}<a href="{{ . }}"><img src="/images/users/rss.svg" alt="" /></a>{{ end }}
         </div>


### PR DESCRIPTION
Including the `rel="me"` attribute in mastodon links allows RO team members to use the `about/` page or their author page as verification links in Mastodon, verifying that they are the RO team members they claim.