### PR TITLE
typo + no HTML

### DIFF
--- a/content/blog/2022-11-23-r-universe-stars-1-en/index.md
+++ b/content/blog/2022-11-23-r-universe-stars-1-en/index.md
@@ -94,4 +94,4 @@ Juan Pablo concludes by saying: _“There are more barriers that can be lowered,
 
 If you want to hear more details about the experience, be sure to watch the protagonists in the video with excerpts from the interview. You can activate the subtitles in English and Spanish.
 
-{{< vimeo 759138370 title="Entrevista a Juan Pablo y Pablo >}}
+{{< vimeo id=759138370 title="Entrevista a Juan Pablo y Pablo" >}}

--- a/content/blog/2022-11-23-r-universe-stars-1-en/index.md
+++ b/content/blog/2022-11-23-r-universe-stars-1-en/index.md
@@ -94,4 +94,4 @@ Juan Pablo concludes by saying: _“There are more barriers that can be lowered,
 
 If you want to hear more details about the experience, be sure to watch the protagonists in the video with excerpts from the interview. You can activate the subtitles in English and Spanish.
 
-{{< vimeo b3116c79b8 title="Entrevista a Juan Pablo y Pablo >}}
+{{< vimeo 759138370 title="Entrevista a Juan Pablo y Pablo >}}

--- a/content/blog/2022-11-23-r-universe-stars-1-en/index.md
+++ b/content/blog/2022-11-23-r-universe-stars-1-en/index.md
@@ -13,11 +13,8 @@ tags:
   - interviews
 # The summary below will be used by e.g. Twitter cards
 description: "This is the first post of our interview series __\"Meeting the stars of the R-universe\"__. We begin our journey in _Argentina_ with a team that uses R and develops R packages in the Argentinean State."
+preface: "[Lee la versión en español de este artículo](/blog/2022/11/23/r-universe-stars-1-es/)"
 ---
-
-<div class="alert alert-info" role="alert">
-<a href="/blog/2022/11/23/r-universe-stars-1-es/" target="_blank">Lee la versión en español de este artículo</a>
-</div>
 
 This is the first post of our interview series __"Meeting the stars of the R-universe"__. We aim to introduce the working groups and people behind the development of software and packages many of us use and which are available through the _R-Universe_.  We want to highlight and explore different teams and projects around the world, the work they do, their processes and users. We begin our journey in _Argentina_  with a team that uses R and develops R packages for the Argentinean State. Be sure to watch the [video](#video-of-the-interview) at the end with excerpts from the interview.
 
@@ -97,6 +94,4 @@ Juan Pablo concludes by saying: _“There are more barriers that can be lowered,
 
 If you want to hear more details about the experience, be sure to watch the protagonists in the video with excerpts from the interview. You can activate the subtitles in English and Spanish.
 
-<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-  <iframe src="https://player.vimeo.com/video/759138370?h=b3116c79b8" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" title="Entrevista a Juan Pablo y Pablo></iframe>
-</div>
+{{< vimeo b3116c79b8 title="Entrevista a Juan Pablo y Pablo >}}

--- a/content/blog/2022-11-23-r-universe-stars-1-es/index.md
+++ b/content/blog/2022-11-23-r-universe-stars-1-es/index.md
@@ -96,4 +96,4 @@ Juan Pablo finaliza diciendo: _“Hay más barreras que se pueden seguir bajando
 
 Si quieres escuchar más detalles sobre la experiencia, no dejes de ver a los protagonistas en el vídeo con extractos de la entrevista. Puedes activar los subtítulos en español y en inglés.
 
-{{< vimeo 759138370 title="Entrevista a Juan Pablo y Pablo >}}
+{{< vimeo id=759138370 title="Entrevista a Juan Pablo y Pablo" >}}

--- a/content/blog/2022-11-23-r-universe-stars-1-es/index.md
+++ b/content/blog/2022-11-23-r-universe-stars-1-es/index.md
@@ -96,4 +96,4 @@ Juan Pablo finaliza diciendo: _“Hay más barreras que se pueden seguir bajando
 
 Si quieres escuchar más detalles sobre la experiencia, no dejes de ver a los protagonistas en el vídeo con extractos de la entrevista. Puedes activar los subtítulos en español y en inglés.
 
-{{< vimeo b3116c79b8 >}}
+{{< vimeo 759138370 title="Entrevista a Juan Pablo y Pablo >}}

--- a/content/blog/2022-11-23-r-universe-stars-1-es/index.md
+++ b/content/blog/2022-11-23-r-universe-stars-1-es/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Conciendo a las estrellas del universo R: comunidad R, intercambiar y aprender"
+title: "Conociendo a las estrellas del universo R: comunidad R, intercambiar y aprender"
 author: 
 - Yanina Bellini Saibene
 - Alejandra Bellini 
@@ -15,12 +15,9 @@ tags:
   - español
   - spanish
 featured: true
-description: "Esta es la primera entrega de nuestra serie de entrevistas __\"Conciendo a las estrellas del universo R\"__. Iniciamos nuestro recorrido en _Argentina_ y con un equipo que utiliza R y desarrolla paquetes de R en el estado Argentino." 
+description: "Esta es la primera entrega de nuestra serie de entrevistas __\"Conociendo a las estrellas del universo R\"__. Iniciamos nuestro recorrido en _Argentina_ y con un equipo que utiliza R y desarrolla paquetes de R en el estado Argentino."
+preface: "[See the English version of this blog post](/blog/2022/11/23/r-universe-stars-1-en/)"
 ---
-
-<div class="alert alert-info" role="alert">
-<a href="/blog/2022/11/23/r-universe-stars-1-en/" target="_blank">See the English version of this blog post</a>
-</div>
 
 Esta es la primera entrega de nuestra serie de entrevistas __"Conociendo a las estrellas del universo R"__. Tenemos como objetivo introducir los grupos de trabajo y las personas que están detrás del desarrollo del software y paquetes que muchos utilizamos y que se encuentran disponibles en _R-Universe_.  Queremos resaltar y conocer diferentes proyectos alrededor del mundo, el trabajo que hacen, sus procesos y usuarios. Iniciamos nuestro recorrido en _Argentina_ y con un equipo que utiliza R y desarrolla paquetes de R en el estado Argentino (no dejes de ver el [vídeo](#video-de-la-entrevista) con extractos de la entrevista).
 
@@ -99,6 +96,4 @@ Juan Pablo finaliza diciendo: _“Hay más barreras que se pueden seguir bajando
 
 Si quieres escuchar más detalles sobre la experiencia, no dejes de ver a los protagonistas en el vídeo con extractos de la entrevista. Puedes activar los subtítulos en español y en inglés.
 
-<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-  <iframe src="https://player.vimeo.com/video/759138370?h=b3116c79b8" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" title="Entrevista a Juan Pablo y Pablo></iframe>
-</div>
+{{< vimeo b3116c79b8 >}}


### PR DESCRIPTION
- fixed a typo
- used the preface YAML parameter (I had forgotten about it myself)
- used the Vimeo shortcode after making the video public on Vimeo. 

I noticed that in the deployed version of the website there was no sidebar, so one of the HTML added in the Markdown had broken something. Now things look ok.