### PR TITLE
less twitter

### DIFF
--- a/archetypes/Rmd/index.md
+++ b/archetypes/Rmd/index.md
@@ -16,18 +16,16 @@ tags:
   - packages
   - R
   - community
-# The summary below will be used by e.g. Twitter cards
+# The summary below will be used by e.g. Mastodon preview cards
 description: "A very short summary of your post (~ 100 characters)"
-# If you have no preferred image for Twitter cards,
-# delete the twitterImg and twitterAlt lines below 
-# - Replace "blog" with "technotes" as needed
-# - Note no "/" symbol before "blog" here
+# If you have no preferred image for Mastodon preview cards,
+# delete the socialImg and socialAlt lines below 
 # - Note "/" between year/month/day
-twitterImg: blog/2019/06/04/post-template/name-of-image.png
-twitterAlt: "Alternative description of the image"
+socialImg: blog/2019/06/04/post-template/name-of-image.png
+socialAlt: "Alternative description of the image"
 # the text below is for populating the "share on Twitter" button
 # if deleted, the title of the post will be used
-tweet: "A post about blabla by @username!"
+social: "A post about blabla by @username@server.extension!"
 ---
 
 This is the R Markdown (.Rmd) template for a blog post or tech note. 

--- a/archetypes/md/index.md
+++ b/archetypes/md/index.md
@@ -16,17 +16,16 @@ tags:
   - packages
   - R
   - community
-# The summary below will be used by e.g. Twitter cards
+# The summary below will be used by e.g. Mastodon preview cards
 description: "A very short summary of your post (~ 100 characters)"
-# If you have no preferred image for Twitter cards,
-# delete the twitterImg and twitterAlt lines below 
-# - Replace "blog" with "technotes" as needed
+# If you have no preferred image for Mastodon preview cards,
+# delete the socialImg and socialAlt lines below 
 # - Note "/" between year/month/day
-twitterImg: blog/2019/06/04/post-template/name-of-image.png
-twitterAlt: "Alternative description of the image"
+socialImg: blog/2019/06/04/post-template/name-of-image.png
+socialAlt: "Alternative description of the image"
 # the text below is for populating the "share on Twitter" button
 # if deleted, the title of the post will be used
-tweet: "A post about blabla by @username!"
+social: "A post about blabla by @username@server.extension!"
 ---
 
 This is the Markdown (.md) template for a blog post or tech note. 

--- a/archetypes/md/index.md
+++ b/archetypes/md/index.md
@@ -23,7 +23,7 @@ description: "A very short summary of your post (~ 100 characters)"
 # - Note "/" between year/month/day
 socialImg: blog/2019/06/04/post-template/name-of-image.png
 socialAlt: "Alternative description of the image"
-# the text below is for populating the "share on Twitter" button
+# the text below is for populating the "share on Mastodon" button
 # if deleted, the title of the post will be used
 social: "A post about blabla by @username@server.extension!"
 ---

--- a/archetypes/newsletter/index.md
+++ b/archetypes/newsletter/index.md
@@ -404,8 +404,8 @@ parse_one_post <- function(path){
     software_peer_review = "Software Peer Review" %in% yaml$tags,
     tech_note = "tech notes" %in% yaml$tags && !"Software Peer Review" %in% yaml$tags,
     other = !"tech notes" %in% yaml$tags && !"Software Peer Review" %in% yaml$tags,
-    twitterImg = yaml$twitterImg %||% "",
-    twitterAlt = yaml$twitterAlt %||% "",
+    socialImg = yaml$socialImg %||% "",
+    socialAlt = yaml$socialAlt %||% "",
     description = yaml$description %||% "",
     newsletter = "newsletter" %in% yaml$tags,
     slug = yaml$slug,
@@ -456,13 +456,13 @@ format_post <- function(dir) {
     string <- paste0(string, ".")  
   }
   
-  if (post$twitterImg != "") {
-    img_file <- fs::path_file(post$twitterImg)
-    download.file(sprintf("https://ropensci.org/%s", post$twitterImg), img_file)
+  if (post$socialImg != "") {
+    img_file <- fs::path_file(post$socialImg)
+    download.file(sprintf("https://ropensci.org/%s", post$socialImg), img_file)
     img_file %>% magick::image_read() %>% magick::image_scale("400x") %>% magick::image_write(img_file)
     string <- paste0(
       string,
-      sprintf('{{< figure src="%s" alt="%s" width="400" >}}\n\n', img_file, post$twitterAlt)
+      sprintf('{{< figure src="%s" alt="%s" width="400" >}}\n\n', img_file, post$socialAlt)
     )
   }
   

--- a/content/blog/2021-11-16-how-to-cite-r-and-r-packages/index.Rmd
+++ b/content/blog/2021-11-16-how-to-cite-r-and-r-packages/index.Rmd
@@ -11,7 +11,7 @@ tags:
   - repeatability
 featured: true
 description: A short primer on how to cite R and R packages to support developers and ensure repeatable science!
-tweet: How to cite R and R packages? by @steffilazerte!
+social: How to cite R and R packages? by @steffilazerte@fosstodon.org!
 output:
   html_document:
     keep_md: yes

--- a/content/blog/2021-11-16-how-to-cite-r-and-r-packages/index.md
+++ b/content/blog/2021-11-16-how-to-cite-r-and-r-packages/index.md
@@ -11,7 +11,7 @@ tags:
   - repeatability
 featured: true
 description: A short primer on how to cite R and R packages to support developers and ensure repeatable science!
-tweet: How to cite R and R packages? by @steffilazerte!
+social: How to cite R and R packages? by @steffilazerte@fosstodon.org!
 output:
   html_document:
     keep_md: yes

--- a/content/blog/2022-08-09-working-with-qualtrics-data-excluding/index.md
+++ b/content/blog/2022-08-09-working-with-qualtrics-data-excluding/index.md
@@ -17,8 +17,8 @@ tags:
 package_version: 0.4.0
 description: "This post summarizes how to use the excluder package to exclude survey data."
 tweet: "Exclude problematic survey data with the excluder R package by @JeffStevensADML!"
-twitterImg: blog/2022/08/09/working-with-qualtrics-data-excluding/excluder_hex.png
-twitterAlt: "Hex sticker for excluder package, which has lines representing rows and red Xes representing excluded rows."
+socialImg: blog/2022/08/09/working-with-qualtrics-data-excluding/excluder_hex.png
+socialAlt: "Hex sticker for excluder package, which has lines representing rows and red Xes representing excluded rows."
 ---
 
 In the [last post](/blog/2022/08/02/working-with-qualtrics-data-importing/), we used the [qualtRics](https://docs.ropensci.org/qualtRics/)[^1] package to import survey data directly from [Qualtrics](https://www.qualtrics.com/) accounts.

--- a/content/blog/2022-12-06-save-ggplot2-targets/index.md
+++ b/content/blog/2022-12-06-save-ggplot2-targets/index.md
@@ -21,7 +21,7 @@ description: "A short exploration of how to save ggplot2 objects in targets work
 # - Replace "blog" with "technotes" as needed
 # - Note no "/" symbol before "blog" here
 # - Note "/" between year/month/day
-# the text below is for populating the "share on Twitter" button
+# the text below is for populating the "share on Mastodon" button
 # if deleted, the title of the post will be used
 tweet: "A post about saving efficiently {ggplot2} objects in a {targets} workflow by @LeNematode!"
 ---

--- a/themes/ropensci/layouts/careers/single.html
+++ b/themes/ropensci/layouts/careers/single.html
@@ -12,7 +12,6 @@
           </div>
                         <div class="col-md-2">
                 <h4 class="share-title mb-3">Share</h4>
-                {{ partial "twitter/share-link" . }}
                 {{ partial "mastodon/share-link" . }}
                 {{ partial "linkedin/share-link" . }}
                 {{ partial "email/share-link" . }}

--- a/themes/ropensci/layouts/commcalls/single.html
+++ b/themes/ropensci/layouts/commcalls/single.html
@@ -156,7 +156,6 @@
             </div>
       <div class="field-under mt-4">
         <span>Share</span>
-        {{ partial "twitter/share-link" . }}
         {{ partial "mastodon/share-link" . }}
         {{ partial "linkedin/share-link" . }}
         {{ partial "email/share-link" . }}

--- a/themes/ropensci/layouts/events/single.html
+++ b/themes/ropensci/layouts/events/single.html
@@ -110,7 +110,6 @@
       <div class="col-md-2">
       <div class="field-under mt-4">
         <span>Share</span>
-        {{ partial "twitter/share-link" . }}
         {{ partial "mastodon/share-link" . }}
         {{ partial "linkedin/share-link" . }}
         {{ partial "email/share-link" . }}

--- a/themes/ropensci/layouts/partials/blogs/blog-single.html
+++ b/themes/ropensci/layouts/partials/blogs/blog-single.html
@@ -69,7 +69,6 @@ For more information, visit the <a href="/r-universe/">r-universe project page</
       {{ end }}
       <div class="field-under mt-4">
         <span>{{ i18n "Share" }}</span>
-        {{ partial "twitter/share-link" . }}
         {{ partial "mastodon/share-link" . }}
         {{ partial "linkedin/share-link" . }}
         {{ partial "email/share-link" . }}

--- a/themes/ropensci/layouts/partials/mastodon/share-url.html
+++ b/themes/ropensci/layouts/partials/mastodon/share-url.html
@@ -1,1 +1,1 @@
-https://toot.kytta.dev/?text={{ if isset .Params "tweet" }}{{ .Params.tweet | replaceRE "&" "%26" }}{{ else }}{{ .Title  | replaceRE "&" "%26" }}{{ end }} {{ .Permalink }}
+https://toot.kytta.dev/?text={{ if isset .Params "social" }}{{ .Params.social | replaceRE "&" "%26" }}{{ else }}{{ if isset .Params "tweet" }}{{ .Params.tweet | replaceRE "&" "%26" }}{{ else }}{{ .Title  | replaceRE "&" "%26" }}{{ end }}{{ end }} {{ .Permalink }}

--- a/themes/ropensci/layouts/partials/skeleton/footer.html
+++ b/themes/ropensci/layouts/partials/skeleton/footer.html
@@ -47,15 +47,6 @@
             </a>
           </li>
           <li>
-            <a lang="en" href="https://twitter.com/ropensci" aria-label="Twitter account for rOpenSci" rel="me">
-              <img
-                class="footer-social__icon"
-                src="/images/svg/social-icons/twitter.svg"
-                alt=""
-              />
-            </a>
-          </li>
-          <li>
             <a lang="en" href="https://hachyderm.io/@rOpenSci" aria-label="Mastodon account for rOpenSci" rel="me">
               <img
                 class="footer-social__icon"

--- a/themes/ropensci/layouts/partials/skeleton/head.html
+++ b/themes/ropensci/layouts/partials/skeleton/head.html
@@ -57,7 +57,12 @@
     <meta property="description" content="{{ $description | default $defaultDescription }}">
     <meta property="og:description" content="{{ $description | default $defaultDescription }}">
   <meta property="og:type" content="article">
-
+{{ if .Params.socialImg }}
+    <meta name="og:image" content="{{ .Params.socialImg | absURL }}" >
+    {{ with .Params.socialAlt }}
+    <meta name="og:image:alt" content="{{ . }}">
+    {{ end }}
+{{ else }}
   {{ if .Params.twitterImg }}
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="{{ .Params.twitterImg | absURL }}" >
@@ -73,6 +78,8 @@
     <meta name="twitter:image" content="{{ "android-chrome-512x512.png"  | absURL }}" >
     <meta name="og:image" content="{{ "android-chrome-512x512.png"  | absURL }}" >
   {{ end }}
+  {{ end }}
+  
 {{ if .Params.math }}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css" integrity="sha384-vKruj+a13U8yHIkAyGgK1J3ArTLzrFGBbBc0tDp4ad/EyewESeXE/Iv67Aj8gKZ0" crossorigin="anonymous">
 {{ end }}

--- a/themes/ropensci/layouts/partials/twitter/share-link.html
+++ b/themes/ropensci/layouts/partials/twitter/share-link.html
@@ -1,6 +1,0 @@
-<a href="{{ partial "twitter/share-url" . }}" class="btn btn-share btn-twitter" target="_blank">
-  <span class="btn-icon">
-    <i class="fab fa-twitter"></i>
-  </span>
-  Twitter
-</a>

--- a/themes/ropensci/layouts/partials/twitter/share-url.html
+++ b/themes/ropensci/layouts/partials/twitter/share-url.html
@@ -1,1 +1,0 @@
-https://twitter.com/intent/tweet?original_referer={{ .Permalink }}&text={{ if isset .Params "tweet" }}{{ .Params.tweet | replaceRE "&" "%26" }}{{ else }}{{ .Title  | replaceRE "&" "%26" }}{{ end }}&url={{ .Permalink }}&via=ropensci


### PR DESCRIPTION
Fix #590

- Remove link to Twitter account from the footer. (is this the right choice?)
- Remove button to share on Twitter from the sidebar of posts, job postings, comm calls. (is this the right choice?)
- New posts will use the "social" metadata, for old ones the templates will still pick up the "twitter" metadata. I have checked the preview on Twitter/Mastodon and Slack for the Qualtrics & cite packages post I edited but would appreciate a second pair of eyes. https://deploy-preview-592--ropensci.netlify.app/blog/2022/08/09/working-with-qualtrics-data-excluding/ + https://deploy-preview-592--ropensci.netlify.app/blog/2021/11/16/how-to-cite-r-and-r-packages/