### PR TITLE
Correct typo in link to other post

### DIFF
--- a/content/blog/2024-03-29-from-the-founding-director-my-farewell-to-ropensci/index.md
+++ b/content/blog/2024-03-29-from-the-founding-director-my-farewell-to-ropensci/index.md
@@ -27,4 +27,4 @@ I'm incredibly excited to see what the future holds for rOpenSci. There's so muc
 
 Thank you for your support, collaboration, and inspiration throughout these years. Here's to the next chapter of innovation and discovery in the rOpenSci community!
 
-[_Read a post from our incoming director, Noam Ross_](/blog/2023/03/29/hello-from-our-new-executive-director/)
+[_Read a post from our incoming director, Noam Ross_](/blog/2024/03/29/hello-from-our-new-executive-director/)


### PR DESCRIPTION
I clicked on the link at the bottom of the post to realize there was a tiny typo in the year of the link 😉 