### PR TITLE
work on acknowledging post editors

### DIFF
--- a/content/blog/2024-01-16-deepl-update-babeldown/index.md
+++ b/content/blog/2024-01-16-deepl-update-babeldown/index.md
@@ -2,6 +2,8 @@
 title: How to Update a Translation with Babeldown
 author: 
 - Maëlle Salmon
+editor:
+- Noam Ross
 date: '2024-01-16'
 slug: deepl-update-babeldown
 categories: []

--- a/content/blog/2024-02-15-intro-champions-2024/index.md
+++ b/content/blog/2024-02-15-intro-champions-2024/index.md
@@ -12,6 +12,8 @@ author:
 - Erika Siregar
 - Jacqui Levy
 - Yanina Bellini Saibene
+editor:
+- Steffi LaZerte
 date: '2024-02-15'
 featured: true
 slug: champions-program-champions-2024

--- a/content/blog/2024-02-22-stylish-code/index.md
+++ b/content/blog/2024-02-22-stylish-code/index.md
@@ -3,6 +3,8 @@ title: Beautiful Code, Because We’re Worth It!
 author: 
 - Maëlle Salmon
 - Yanina Bellini Saibene
+editor:
+- Steffi LaZerte
 date: '2024-02-22'
 slug: beautiful-code
 output: hugodown::md_document

--- a/content/blog/2024-03-07-package-marketing/index.md
+++ b/content/blog/2024-03-07-package-marketing/index.md
@@ -3,6 +3,8 @@ title: Marketing Ideas For Your Package
 author:
 - Yanina Bellini Saibene
 - Maëlle Salmon
+editor:
+- Steffi LaZerte
 date: '2024-03-07'
 slug: package-marketing
 tags:

--- a/content/blog/2024-03-11-devguide-release-0.9.0/index.es.md
+++ b/content/blog/2024-03-11-devguide-release-0.9.0/index.es.md
@@ -4,6 +4,8 @@ author:
 - Maëlle Salmon
 - Mark Padgham
 - Noam Ross
+editor:
+- Yanina Bellini Saibene
 date: '2024-03-11'
 slug: r_open_sci_dev_guide_0_9_0_ahora_multilingüe_y_mejor
 tags:

--- a/content/blog/2024-03-18-package-testing-principles/index.md
+++ b/content/blog/2024-03-18-package-testing-principles/index.md
@@ -2,6 +2,8 @@
 title: An Example of the DRY/DAMP Principles for Package Tests 
 author: 
 - Maëlle Salmon
+editor:
+- Steffi LaZerte
 date: '2024-03-18'
 slug: dry-damp
 output: hugodown::md_document

--- a/content/blog/2024-03-20-champions-program-projects/index.md
+++ b/content/blog/2024-03-20-champions-program-projects/index.md
@@ -3,7 +3,8 @@ title: "rOpenSci Champions Pilot Year: Projects Wrap-Up"
 slug: "champions-program-projects-cohort1"
 author:
   - Yanina Bellini Saibene
-
+editor:
+- Steffi LaZerte
 date: '2024-03-20'
 tags:
   - community

--- a/content/blog/2024-04-12-gsod-announcement/index.md
+++ b/content/blog/2024-04-12-gsod-announcement/index.md
@@ -3,6 +3,8 @@ slug: "gsod-announcement"
 title: R-Universe Documentation Gets a Boost from Google Season of Docs
 author:
   - Noam Ross
+editor:
+- Steffi LaZerte
 date: 2024-04-12
 tags:
   - r-universe

--- a/content/blog/2024-04-18-fostering-equity-and-leadership/index.en.md
+++ b/content/blog/2024-04-18-fostering-equity-and-leadership/index.en.md
@@ -5,6 +5,8 @@ author:
     - Yanina Bellini Saibene
     - Camille Santistevan
     - Lou Woodley
+editor:
+- Steffi LaZerte
 date: '2024-04-18'
 slug: champions-program-2024
 categories:

--- a/content/blog/2024-05-17-communication-tips-oss-project/index.Rmd
+++ b/content/blog/2024-05-17-communication-tips-oss-project/index.Rmd
@@ -2,6 +2,8 @@
 title: Communication Tips for your Open-Source Project
 author: 
 - Maëlle Salmon
+editor:
+- Mark Padgham
 date: '2024-05-17'
 slug: communication-tips-oss-project
 output: hugodown::md_document

--- a/content/blog/2024-05-17-communication-tips-oss-project/index.md
+++ b/content/blog/2024-05-17-communication-tips-oss-project/index.md
@@ -2,6 +2,8 @@
 title: Communication Tips for your Open-Source Project
 author: 
 - Maëlle Salmon
+editor:
+- Mark Padgham
 date: '2024-05-17'
 slug: communication-tips-oss-project
 output: hugodown::md_document

--- a/themes/ropensci/i18n/en.toml
+++ b/themes/ropensci/i18n/en.toml
@@ -3,6 +3,9 @@
 
 [By]
   other = 'By'
+
+[Edited-by]
+  other = 'Edited by'
   
 [Filed-under]
   other = 'Filed under'

--- a/themes/ropensci/i18n/es.toml
+++ b/themes/ropensci/i18n/es.toml
@@ -3,6 +3,9 @@
 
 [By]
   other = 'Por'
+
+[Edited-by]
+  other = 'Editado por'
   
 [Filed-under]
   other = 'Categorias'

--- a/themes/ropensci/i18n/fr.toml
+++ b/themes/ropensci/i18n/fr.toml
@@ -3,6 +3,9 @@
 
 [By]
   other = 'Par'
+
+[Edited-by]
+  other = 'Édité par'
   
 [Filed-under]
   other = 'Catégories'

--- a/themes/ropensci/layouts/partials/blogs/blog-single.html
+++ b/themes/ropensci/layouts/partials/blogs/blog-single.html
@@ -11,6 +11,12 @@
           {{ i18n "By" }}
           </span> 
           {{ partial "blogs/pretty_author_names" .Params.author }}
+          {{ with .Params.editor }}
+          <span>
+          &#8211; {{ i18n "Edited-by" }}
+          </span> 
+          {{ partial "blogs/pretty_author_names" . }}
+          {{ end }}
           </div>
         </div>
     </div>


### PR DESCRIPTION
Examples:
- https://deploy-preview-765--ropensci.netlify.app/blog/2024/05/17/communication-tips-oss-project/
- https://deploy-preview-765--ropensci.netlify.app/blog/2024/03/07/package-marketing/

Questions
- Does it look good?
- How do we backfill the editor field of older posts?
- Should we later consider adding a list of posts edited by a person, on that person's author page?
- This won't appear on R Bloggers and Rogue Scholar as far as I know. I could ask Rogue Scholar what the field for editors could be.