### PR TITLE
Update LatinR domain

### DIFF
--- a/content/blog/2023-12-05-divide-y-venceras-de-polar-al-polarverse/index.en.md
+++ b/content/blog/2023-12-05-divide-y-venceras-de-polar-al-polarverse/index.en.md
@@ -45,7 +45,7 @@ R Since then it has become a fundamental tool in my daily life: As [academic](ht
 
 Of all the qualities that R has, the **community** was the determining factor in my journey with this programming language.
 
-While I was finishing the first step of the thesis, I found out about the organization of the first [Latin American Conference on R for R\&D (LatinR)](https://latin-r.com/) to which I owe my second (and third... and umpteenth) step in my relationship with R. In the first conference I presented use cases for political analyses from R, implementing [grids from Argentina to use with ggplot as if they were maps with geofacet](https://www.researchgate.net/publication/327382101_Geofaceting_Argentina_LatinR_2018). In the second conference, we presented the *Shiny App* [Electoral Intelligence](http://inteligenciaelectoral.mentacomunicacion.com.ar/) for the analysis of electoral results in Argentina and I was able to participate in the *Package Development* workshop with [Hadley Wickham](https://hadley.nz/). This was the ideal starting point to get started with the idea of packaging code myself.
+While I was finishing the first step of the thesis, I found out about the organization of the first [Latin American Conference on R for R\&D (LatinR)](https://latinr.org/) to which I owe my second (and third... and umpteenth) step in my relationship with R. In the first conference I presented use cases for political analyses from R, implementing [grids from Argentina to use with ggplot as if they were maps with geofacet](https://www.researchgate.net/publication/327382101_Geofaceting_Argentina_LatinR_2018). In the second conference, we presented the *Shiny App* [Electoral Intelligence](http://inteligenciaelectoral.mentacomunicacion.com.ar/) for the analysis of electoral results in Argentina and I was able to participate in the *Package Development* workshop with [Hadley Wickham](https://hadley.nz/). This was the ideal starting point to get started with the idea of packaging code myself.
 
 
 {{< figure src = "hex_joint.png" width = "600" alt = "geofecetAR R package hex logo on the left and original polAr R package hex logo on the right" class = "center">}}
@@ -80,7 +80,7 @@ I presented "[Divide and Conquer: from {polAr} to the polarverse](https://github
 
 4. 📦 [discursAr](https://politicaargentina.r-universe.dev/discursAr): is designed to obtain data on political speeches. In principle, it provides access to presidential speeches in legislative assemblies at the inauguration of ordinary sessions.
 
-5. 📦 [geoAr](https://politicaargentina.r-universe.dev/geoAr): allows access to data and tools for spatial workflows from within R. One [paper](https://github.com/TuQmano/latinr2023/blob/main/geoAr/geoAr.pdf) on the package was accepted for the [sixth edition of LatinR conference (2023)](https://latin-r.com/).
+5. 📦 [geoAr](https://politicaargentina.r-universe.dev/geoAr): allows access to data and tools for spatial workflows from within R. One [paper](https://github.com/TuQmano/latinr2023/blob/main/geoAr/geoAr.pdf) on the package was accepted for the [sixth edition of LatinR conference (2023)](https://latinr.org/).
 
 In addition, we worked on an auxiliary library called [polarViz](https://politicaargentina.r-universe.dev/polArViz) to facilitate the visualization of the other packages, and a metapackage called [polArverse](https://politicaargentina.r-universe.dev/polArverse)that emulates the operation of tidyverse for loading the set of associated libraries.
 

--- a/content/blog/2023-12-05-divide-y-venceras-de-polar-al-polarverse/index.es.md
+++ b/content/blog/2023-12-05-divide-y-venceras-de-polar-al-polarverse/index.es.md
@@ -45,7 +45,7 @@ R desde entonces en una herramienta fundamental de mi día a día. Lo es en el �
 
 De todas las cualidades que tiene R, **la comunidad** fue el factor determinante en mi recorrido con este lenguaje de programación.
 
-Al tiempo que finalizaba el primer paso de la tesis, me enteraba de la organización de la primera [Conferencia Latinoamericana de R para I+D (LatinR)](https://latin-r.com/), comunidad a la que le debo mi segundo (y tercero... y enesimo) paso en mi relación con R. En la primera conferencia presenté casos de uso para análisis político desde R, implementando [grillas de Argentina para usar con ggplot como si fueran mapas con geofacet](https://www.researchgate.net/publication/327382101_Geofaceting_Argentina_LatinR_2018). En la segunda conferencia, presentamos la *Shiny App* [Inteligencia Electoral](http://inteligenciaelectoral.mentacomunicacion.com.ar/) para el análisis de resultados electorales de Argentina y pude participar del taller  _Desarrollo de Paquetes_ con [Hadley Wickham](https://hadley.nz/). Fue éste el punto de partida ideal para empezar con la idea de empaquetar código yo mismo.
+Al tiempo que finalizaba el primer paso de la tesis, me enteraba de la organización de la primera [Conferencia Latinoamericana de R para I+D (LatinR)](https://latinr.org/), comunidad a la que le debo mi segundo (y tercero... y enesimo) paso en mi relación con R. En la primera conferencia presenté casos de uso para análisis político desde R, implementando [grillas de Argentina para usar con ggplot como si fueran mapas con geofacet](https://www.researchgate.net/publication/327382101_Geofaceting_Argentina_LatinR_2018). En la segunda conferencia, presentamos la *Shiny App* [Inteligencia Electoral](http://inteligenciaelectoral.mentacomunicacion.com.ar/) para el análisis de resultados electorales de Argentina y pude participar del taller  _Desarrollo de Paquetes_ con [Hadley Wickham](https://hadley.nz/). Fue éste el punto de partida ideal para empezar con la idea de empaquetar código yo mismo.
 
 {{< figure src = "hex_joint.png" width = "600" alt = "el hex logo del paquete de R geofecetAR a la izquierda y el de polAr a la derecha" class = "center">}}
 
@@ -78,7 +78,7 @@ Presentamos "[Divide y Vencerás: de {polAr} al polarverse](https://github.com/T
 
 4. 📦 [discursAr](https://politicaargentina.r-universe.dev/discursAr)`:` pensado para obtener datos relativos a discursos políticos. En principio proveyendo acceso a discursos presidenciales en asambleas legislativas de inauguración de sesiones ordinarias.
 
-5. 📦 [geoAr](https://politicaargentina.r-universe.dev/geoAr): permite acceder a datos y herramientas para flujos de trabajo espaciales desde R. Una [ponencia](https://github.com/TuQmano/latinr2023/blob/main/geoAr/geoAr.pdf) sobre el paquete fue aceptada para la [sexta conferencia de LatinR](https://latin-r.com/).
+5. 📦 [geoAr](https://politicaargentina.r-universe.dev/geoAr): permite acceder a datos y herramientas para flujos de trabajo espaciales desde R. Una [ponencia](https://github.com/TuQmano/latinr2023/blob/main/geoAr/geoAr.pdf) sobre el paquete fue aceptada para la [sexta conferencia de LatinR](https://latinr.org/).
 
 Adicionalmente trabajamos en una librería auxiliar llamada [polarViz](https://politicaargentina.r-universe.dev/polArViz), para facilitar la tarea de visualización de los otros paquetes, y un metapaquete [polArverse](https://politicaargentina.r-universe.dev/polArverse)que emula el funcionamiento de tidyverse, para la carga del conjunto de librerías asociadas.
 


### PR DESCRIPTION
LatinR domain used to be latin-r.com, but recently changed to latinr.org
The conference is cited in the blogpost from JP Ruiz Nicolini, and the link is broken.
This PR fixes the links for the conference in that blogpost!

@yabellini 