### PR TITLE
Work towards a training page with past material

### DIFF
--- a/content/events/2020-07-09-user.md
+++ b/content/events/2020-07-09-user.md
@@ -4,7 +4,7 @@ dateStart: '2020-07-09T8:00:00'
 dateEnd: '2020-07-09T20:00:00'
 date: '2020-07-09T20:00:00'
 description: 'Noam and Scott giving talks'
-location: 'Online'
+location: 'online'
 country: '🌐'
 attendees:
   - Noam Ross

--- a/content/events/2021-07-05-useR2021.md
+++ b/content/events/2021-07-05-useR2021.md
@@ -4,7 +4,7 @@ dateStart: '2021-07-05T8:00:00'
 dateEnd: '2021-07-09T20:00:00'
 date: '2021-07-09T20:00:00'
 description: 'rOpenSci staff give keynote, tutorial, and 2 talks at useR!2021'
-location: 'Online'
+location: 'online'
 country: '🌐'
 deets: Refer to [useR! 2021 website](https://user2021.r-project.org/).
 attendees:

--- a/content/events/2023-03-01-mentor-orientation.md
+++ b/content/events/2023-03-01-mentor-orientation.md
@@ -1,5 +1,6 @@
 ---
 title: 'rOpenSci Champions Program. Mentorship Training and Orientation'
+training: true
 dateStart: '2023-02-21T11:00:00'
 dateEnd: '2023-02-21T11:00:00'
 date: 2023-02-21T14:00:00 # UTC!! same as dateEnd

--- a/content/events/2023-04-04-how-ropensci-review.md
+++ b/content/events/2023-04-04-how-ropensci-review.md
@@ -1,5 +1,6 @@
 ---
 title: 'How rOpenSci performs peer-review (champions training)'
+training: true
 dateStart: '2023-04-04T17:00:00'
 dateEnd: '2023-04-04T17:00:00'
 date: 2023-04-04T17:00:00 # UTC!! same as dateEnd

--- a/content/events/2023-05-18-how-to-contribute-base-r.md
+++ b/content/events/2023-05-18-how-to-contribute-base-r.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to contribute to base R (champions training)'
+training: true
 dateStart: '2023-05-18T17:00:00'
 dateEnd: '2023-05-18T17:00:00'
 date: 2023-05-18T17:00:00 # UTC!! same as dateEnd

--- a/content/events/2023-05-19-developing-software-together.md
+++ b/content/events/2023-05-19-developing-software-together.md
@@ -1,5 +1,6 @@
 ---
 title: 'Developing Software Together (training for champions program applicants)'
+training: true
 dateStart: '2023-05-19T17:00:00'
 dateEnd: '2023-05-19T17:00:00'
 date: 2023-05-19T17:00:00 # UTC!! same as dateEnd

--- a/content/events/2024-02-15-mentor-orientation.md
+++ b/content/events/2024-02-15-mentor-orientation.md
@@ -3,7 +3,7 @@ title: 'rOpenSci Champions Program. Mentorship Training and Orientation'
 training: true
 dateStart: '2024-02-15T11:00:00'
 dateEnd: '2024-02-15T14:00:00'
-date: 2023-02-15T14:00:00 # UTC!! same as dateEnd
+date: 2024-02-15T14:00:00 # UTC!! same as dateEnd
 description: ""
 location: 'online'
 country: "\U0001F310" # emoji

--- a/content/events/2024-02-15-mentor-orientation.md
+++ b/content/events/2024-02-15-mentor-orientation.md
@@ -1,0 +1,23 @@
+---
+title: 'rOpenSci Champions Program. Mentorship Training and Orientation'
+training: true
+dateStart: '2024-02-15T11:00:00'
+dateEnd: '2024-02-15T14:00:00'
+date: 2023-02-15T14:00:00 # UTC!! same as dateEnd
+description: ""
+location: 'online'
+country: "\U0001F310" # emoji
+tags: 
+  - champions
+author:
+  - Yanina Bellini Saibene
+attendees:
+  - Yanina Bellini Saibene
+resources: # can be added later, one entry per talk (don't add while still empty, add once there are resources)
+  - title: "rOpenSci Champions Program. Mentorship Training and Orientation"
+    speaker: Yanina Bellini Saibene
+    slides: https://ropensci-training.github.io/ropensci-mentors/
+    language: en
+---
+
+

--- a/content/events/2024-02-15-stylish-code.md
+++ b/content/events/2024-02-15-stylish-code.md
@@ -1,0 +1,23 @@
+---
+title: 'Beautiful code, because we’re worth it! (champions training)'
+training: true
+dateStart: '2024-02-15T17:00:00'
+dateEnd: '2024-02-15T18:00:00'
+date: 2024-02-15T18:00:00 # UTC!! same as dateEnd
+description: ""
+location: 'online'
+country: "\U0001F310" # emoji
+tags: 
+  - champions
+author:
+  - Maëlle Salmon
+attendees:
+  - Maëlle Salmon
+resources: # can be added later, one entry per talk (don't add while still empty, add once there are resources)
+  - title: "Beautiful code, because we’re worth it!"
+    speaker: Maëlle Salmon
+    slides: https://stylish-code.netlify.app/#/
+    language: en
+---
+
+

--- a/content/events/2024-03-01-pkg-dev-mechanics-champions.md
+++ b/content/events/2024-03-01-pkg-dev-mechanics-champions.md
@@ -1,9 +1,9 @@
 ---
 title: 'Package Development: the Mechanics (champions training)'
 training: true
-dateStart: '2023-03-14T11:00:00'
-dateEnd: '2023-03-14T11:00:00'
-date: 2023-03-14T14:00:00 # UTC!! same as dateEnd
+dateStart: '2024-03-01T11:00:00'
+dateEnd: '2024-03-01T11:00:00'
+date: 2024-03-01T14:00:00 # UTC!! same as dateEnd
 description: ""
 location: 'online'
 country: "\U0001F310" # emoji
@@ -16,7 +16,7 @@ attendees:
 resources: # can be added later, one entry per talk (don't add while still empty, add once there are resources)
   - title: "Package Development: the Mechanics (champions training)"
     speaker: Maëlle Salmon
-    slides: https://rpkgdev-mechanics.netlify.app/
+    slides: https://rpkgdev-mechanics-2024.netlify.app/
     language: en
     summary: '“Develop an R package”, they said… What does this even mean? In this session with a live demo, we shall demystify the creation of an R package. R packages are mostly well-organized folders, and there are automatic tools to help. Let’s dive into the wonders of usethis!'
 ---

--- a/content/events/2024-04-01-pkg-dev-not-rocket-science-champions.md
+++ b/content/events/2024-04-01-pkg-dev-not-rocket-science-champions.md
@@ -1,9 +1,9 @@
 ---
 title: 'Package Development: Not Rocket Science (champions training)'
 training: true
-dateStart: '2023-03-23T11:00:00'
-dateEnd: '2023-03-23T11:00:00'
-date: 2023-03-23T11:00:00 # UTC!! same as dateEnd
+dateStart: '2024-03-01T11:00:00'
+dateEnd: '2024-03-01T11:00:00'
+date: 2024-03-01T11:00:00 # UTC!! same as dateEnd
 description: ""
 location: 'online'
 country: "\U0001F310" # emoji
@@ -16,7 +16,7 @@ attendees:
 resources: # can be added later, one entry per talk (don't add while still empty, add once there are resources)
   - title: "Package Development: Not Rocket Science (champions training)"
     speaker: Maëlle Salmon
-    slides: https://rpkgdev-rocket.netlify.app/
+    slides: https://rpkgdev-rocket-2024.netlify.app/
     language: en
     summary: Workshop for R users who’ve already developped or contributed to packages. Ideally, come with a package of yours to use as a playground.
 ---

--- a/content/events/2024-04-03-Champions.md
+++ b/content/events/2024-04-03-Champions.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to contribute to open projects and communities'
+training: true
 dateStart: '2024-04-03T08:30:00'
 dateEnd: '2024-04-03T09:00:00'
 date: 2024-04-03T09:00:00 # UTC!! same as dateEnd

--- a/content/events/2024-04-03-Champions.md
+++ b/content/events/2024-04-03-Champions.md
@@ -5,8 +5,8 @@ dateStart: '2024-04-03T08:30:00'
 dateEnd: '2024-04-03T09:00:00'
 date: 2024-04-03T09:00:00 # UTC!! same as dateEnd
 description: "Yanina led a discussion on community and open source projects, focusing on participation, contribution, and the concept of the ‘pathway to inclusion’ and CSCCE Community particiption model. She presented various models of community participation and outlined strategies for promoting and sharing open-source software packages. The team also discussed the importance of clear communication, a code of conduct, contribution guideles and the use of issue templates and issues labels on Github to streamline the management of issues related to a package."
-location: 'Online'
-country: "Online" # emoji
+location: 'online'
+country: '🌐'
 slug: "champions-contribute-oss-2024"
 ropensci: si
 outputs: 

--- a/content/events/2024-04-17-how-ropensci-review.md
+++ b/content/events/2024-04-17-how-ropensci-review.md
@@ -1,0 +1,25 @@
+---
+title: 'How rOpenSci performs peer-review (champions training)'
+training: true
+dateStart: '2024-04-17T17:00:00'
+dateEnd: '2024-04-17T19:00:00'
+date: 2024-04-17T17:00:00 # UTC!! same as dateEnd
+description: ""
+location: 'online'
+country: "\U0001F310" # emoji
+tags: 
+  - champions
+author:
+  - Mauro Lepore
+  - Noam Ross
+attendees:
+  - Mauro Lepore
+  - Noam Ross
+resources: # can be added later, one entry per talk (don't add while still empty, add once there are resources)
+  - title: "How rOpenSci performs peer-review"
+    speaker: Mauro Lepore
+    slides: https://github.com/maurolepore/ropensci-review
+    language: en
+---
+
+

--- a/content/events/2024-06-04-SER.md
+++ b/content/events/2024-06-04-SER.md
@@ -4,7 +4,7 @@ dateStart: '2024-06-04T08:30:00'
 dateEnd: '2024-06-04T09:00:00'
 date: 2024-06-04T09:00:00 # UTC!! same as dateEnd
 description: "Yanina is part of the Scientific Committee of the VIII Seminário Internacional de Estatística com R (SER) and will be presenting how we use AI in our multilingual project."
-location: 'Online'
+location: 'online'
 country: "Brazil" # emoji
 slug: "ser-ropensci-2024"
 ropensci: no

--- a/content/events/2024-07-23-developing-software-together.md
+++ b/content/events/2024-07-23-developing-software-together.md
@@ -1,5 +1,6 @@
 ---
 title: 'Developing Software Together (training for champions program applicants)'
+training: true
 dateStart: '2024-07-23T21:00:00'
 dateEnd: '2024-07-23T21:00:00'
 date: 2024-07-24T23:59:00 # UTC!! same as dateEnd

--- a/content/talks-papers/_index.md
+++ b/content/talks-papers/_index.md
@@ -1,4 +1,4 @@
 +++
-title="Talks and Publications"
+title="Talks, Training, Publications"
 +++
 

--- a/content/training/_index.md
+++ b/content/training/_index.md
@@ -1,0 +1,5 @@
++++
+title="Training"
++++
+
+A searchable table of more or less recents training sessions given by rOpenSci team members or people representing rOpenSci.

--- a/data/resources/resources.json
+++ b/data/resources/resources.json
@@ -50,8 +50,8 @@
    "url": "https://books.ropensci.org"
 },
 {
-   "title": "Talks and Publications",
-   "text": "External communications about our work",
+   "title": "Talks, Training and Publications",
+   "text": "External communications about our work and teaching",
    "url": "https://ropensci.org/talks-papers/"
 },
 {

--- a/themes/ropensci/layouts/partials/resources/talk-card.html
+++ b/themes/ropensci/layouts/partials/resources/talk-card.html
@@ -11,7 +11,7 @@
       </a>
       <div class="talk-info">
         <span class="talk-date">{{ $date }} • {{ .speaker }}</span>
-        <span class="talk-location">{{ $country }} {{ $location }}</span>
+        <span class="talk-location">{{ $location }}, {{ $country }}</span>
       </div>
     </div>
     <div class="col-md-2 text-md-center"><a href="{{ .slides }}"><i class="fas fa-desktop"></i></a>

--- a/themes/ropensci/layouts/partials/skeleton/navbar.html
+++ b/themes/ropensci/layouts/partials/skeleton/navbar.html
@@ -82,6 +82,7 @@
           <a class="nav-link" lang="en" href="/resources/">Resources</a>
           <ul class="sub-menu">
             <li><a lang="en" href="/talks-papers/">Talks & Publications</a></li>
+            <li><a lang="en" href="/training/">Training materials</a></li>
             <li><a class="external-link" lang="en" href="https://docs.ropensci.org/">Package Docs</a></li>
           </ul>
         </li>

--- a/themes/ropensci/layouts/partials/talks/talk-table.html
+++ b/themes/ropensci/layouts/partials/talks/talk-table.html
@@ -1,0 +1,41 @@
+<section class="section section-generic">
+  <div class="container">
+    <!-- Header text -->
+    <div class="row">
+      <div class="col-md-8 content">
+        <h1>{{ .Title | markdownify }}</h1>
+         {{ .Content }}
+    </div>
+    </div>
+      <table id="talkstable" class="display" width="100%">
+        <thead>
+          <tr>
+    <th>Title</th>
+    <th>Speaker</th>
+    <th>Year</th>
+    <th>Material</th>
+    <th>Language</th>
+  </tr>
+  </thead>
+      <tbody>
+      {{ range (where (where ( where .Site.RegularPages.ByDate.Reverse "Section" "events" ) ".Params.resources" "!=" nil)  ".Params.training" "!=" "true")}}
+      {{ $year := .Date.Format "2006" }}
+      {{ range .Params.resources }}
+   <tr>
+     
+    <td>{{ .title }}</td>
+    <td>{{ .speaker }} </td>
+    <td>{{ $year }} </td>
+    <td>{{ with .slides }}<a href="{{ . }}"><i class="fas fa-desktop"></i></a>{{ end }}
+    {{ if isset . "slides" }}{{ if isset . "video"}} • {{ end }}{{ end }}
+      {{ with .video }} <a href="{{ . }}"><i class="fas fa-film"></i></a>{{ end }} </td>
+    <td>
+      {{ if isset . "language" }} {{ .language }} {{else }} en {{ end }}
+</td>
+  </tr>
+      {{ end }} 
+      {{ end }} 
+      </tbody>
+      </table>
+{{ partial "datatables/scripts" ( dict "id" "talkstable" "col" 2 "order" "desc" )  }}
+</section>

--- a/themes/ropensci/layouts/partials/talks/talk-table.html
+++ b/themes/ropensci/layouts/partials/talks/talk-table.html
@@ -18,7 +18,7 @@
   </tr>
   </thead>
       <tbody>
-      {{ range (where (where ( where .Site.RegularPages.ByDate.Reverse "Section" "events" ) ".Params.resources" "!=" nil)  ".Params.training" "!=" "true")}}
+      {{ range .Pages }}
       {{ $year := .Date.Format "2006" }}
       {{ range .Params.resources }}
    <tr>

--- a/themes/ropensci/layouts/talks-papers/list.html
+++ b/themes/ropensci/layouts/talks-papers/list.html
@@ -12,7 +12,14 @@
       </div>
     </div>
     <div class="talk-cards">
-      {{ range ( first 3 ( where ( where .Site.RegularPages "Section" "events" ) ".Params.resources" "!=" nil  )) }}
+      {{ range ( first 3 (where (where ( where .Site.RegularPages.ByDate.Reverse "Section" "events" ) ".Params.resources" "!=" nil)  ".Params.training" "!=" true)) }}
+      {{ partial "resources/talk-card" . }}
+      {{ end }}
+    </div>
+    <h2 class="title mt-5" id="talks">Training</h2>
+        <p class="content">Most recent training sessions by the rOpenSci team or community members representing us, in various languages. Links to slides and videos are provided where available. <a href="/training">More training</a>.</p>
+    <div class="talk-cards">
+      {{ range ( first 3 (where (where ( where .Site.RegularPages.ByDate.Reverse "Section" "events" ) ".Params.resources" "!=" nil)  ".Params.training" "==" true)) }}
       {{ partial "resources/talk-card" . }}
       {{ end }}
     </div>

--- a/themes/ropensci/layouts/talks/list.html
+++ b/themes/ropensci/layouts/talks/list.html
@@ -1,45 +1,5 @@
 {{ define "main" }}
-<section class="section section-generic">
-  <div class="container">
-    <!-- Header text -->
-    <div class="row">
-      <div class="col-md-8 content">
-        <h1>{{ .Title | markdownify }}</h1>
-         {{ .Content }}
-    </div>
-    </div>
-      <table id="talkstable" class="display" width="100%">
-        <thead>
-          <tr>
-    <th>Title</th>
-    <th>Speaker</th>
-    <th>Year</th>
-    <th>Material</th>
-    <th>Language</th>
-  </tr>
-  </thead>
-      <tbody>
-      {{ range (where ( where .Site.RegularPages.ByDate.Reverse "Section" "events" ) ".Params.resources" "!=" nil  )}}
-      {{ $year := .Date.Format "2006" }}
-      {{ range .Params.resources }}
-   <tr>
-     
-    <td>{{ .title }}</td>
-    <td>{{ .speaker }} </td>
-    <td>{{ $year }} </td>
-    <td>{{ with .slides }}<a href="{{ . }}"><i class="fas fa-desktop"></i></a>{{ end }}
-    {{ if isset . "slides" }}{{ if isset . "video"}} • {{ end }}{{ end }}
-      {{ with .video }} <a href="{{ . }}"><i class="fas fa-film"></i></a>{{ end }} </td>
-    <td>
-      {{ if isset . "language" }} {{ .language }} {{else }} en {{ end }}
-</td>
-  </tr>
-      {{ end }} 
-      {{ end }} 
-      </tbody>
-      </table>
-{{ partial "datatables/scripts" ( dict "id" "talkstable" "col" 2 "order" "desc" )  }}
-</section>
+{{ partial "talks/talk-table" . }}
 {{ partial "whole-page-fragments/ask"  (dict "divider" "lr" ) }}
 {{ partial "whole-page-fragments/newsletter"  (dict "divider" "rl" ) }}
 {{ partial "whole-page-fragments/brands"  (dict "Site" .Site "divider" "lr" ) }}

--- a/themes/ropensci/layouts/training/list.html
+++ b/themes/ropensci/layouts/training/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ $pages := (where (where ( where .Site.RegularPages.ByDate.Reverse "Section" "events" ) ".Params.resources" "!=" nil)  ".Params.training" "!=" true) }}
+{{ $pages := (where (where ( where .Site.RegularPages.ByDate.Reverse "Section" "events" ) ".Params.resources" "!=" nil)  ".Params.training" "==" true) }}
 {{ partial "talks/talk-table" (dict "Pages" $pages "Title" .Title "Content" .Content) }}
 {{ partial "whole-page-fragments/ask"  (dict "divider" "lr" ) }}
 {{ partial "whole-page-fragments/newsletter"  (dict "divider" "rl" ) }}


### PR DESCRIPTION
Fix #844

We'd need to do some backfilling so that things will look better.

Contrary to other events where we create the event Markdown file in advance, here we can't do that as most training sessions are not public.