### PR TITLE
Remove R-universe comm call alert

### DIFF
--- a/themes/ropensci/layouts/r-universe/list.html
+++ b/themes/ropensci/layouts/r-universe/list.html
@@ -8,17 +8,6 @@
         <div class="row">
             <div class="col-lg-8 software-content content">
                 <h1>{{ .Title }}</h1>
-               {{ $t := time.AsTime "2024-09-24T17:00:00" }}
-                {{ if ge $t.UTC now.UTC }}
-                <div class="alert alert-info" role="alert">
-                  <p style="margin-bottom:1rem;">
-                    Don't miss our upcoming community call
-                    <a href="/commcalls/nov2024-r-universe/">"Navigating the R ecosystem using R-universe"</a>
-                    on Tuesday, 24 September 2024 16:00 UTC!
-                    More information on the <a href="/commcalls/nov2024-r-universe/">event page</a>.
-                  <p>
-                </div>
-                {{ end }}
                 {{ .Content }}
             </div>
             <div class="col-lg-4 mt-4">


### PR DESCRIPTION
It removes it from the source, it already no longer appears on the website thanks to the template logic.