### PR TITLE
use DOI in RSS feed

### DIFF
--- a/themes/ropensci/layouts/blog/list.json.json
+++ b/themes/ropensci/layouts/blog/list.json.json
@@ -23,13 +23,13 @@
        {{  $data.Set "authors" (slice .Params.author) }}
     {{ end }}
 			{
-				"id": "{{ .Permalink }}",
+				"id": "{{ .Params.doi }}",
 				"title": "{{ .Title }}",
 				"language" : "{{ .Lang }}",
 				"authors": [{{ range $i, $e := ($data.Get "authors") }}{{ range first 1 (where ($data.Get "pages") ".Params.name" $e) }}{{ $params := .Params }}{{ $name := $params.name }}{{ if $i }}, {{ end }}{{ range first 1 (where ($data.Get "pages") ".Params.name" $e) }}
 				{
       "name": "{{ $name }}",
-      "url": "{{ if isset .Params "orcid" }}https://orcid.org/{{ .Params.orcid }}{{ else }}{{ .Permalink }}{{ end }}",
+      "url": "{{ .Permalink }}",
       "avatar": "{{ ( partial "blogs/author-img" . ) }}"
     }{{ end }}{{ end }}{{ end }}],
 				{{ with .Params.tags }} "tags": {{ . | uniq | jsonify}},{{ end }}

--- a/themes/ropensci/layouts/blog/list.json.json
+++ b/themes/ropensci/layouts/blog/list.json.json
@@ -23,7 +23,7 @@
        {{  $data.Set "authors" (slice .Params.author) }}
     {{ end }}
 			{
-				"id": "{{ .Params.doi }}",
+				"id": "{{ printf "https://doi.org/%s" .Params.doi }}",
 				"title": "{{ .Title }}",
 				"language" : "{{ .Lang }}",
 				"authors": [{{ range $i, $e := ($data.Get "authors") }}{{ range first 1 (where ($data.Get "pages") ".Params.name" $e) }}{{ $params := .Params }}{{ $name := $params.name }}{{ if $i }}, {{ end }}{{ range first 1 (where ($data.Get "pages") ".Params.name" $e) }}


### PR DESCRIPTION
Part of #970


@mfenner is this what you mean? The id here is the DOI string, like "10.59350/8vw43-jy784": should it be the full URL at doi dot org instead?