### PR TITLE
add more staff asides

### DIFF
--- a/content/coworking/_index.es.md
+++ b/content/coworking/_index.es.md
@@ -1,11 +1,11 @@
-+++
-title = "Sesiones de trabajo"
-+++
-
-**Participa en nuestras reuniones de co-trabajo, socialización y horas de oficina los primeros martes de cada mes.
-Organizado por la Asistente de la Comunidad de rOpenSci [Steffi LaZerte](/author/steffi-lazerte) y varias personas de la comunidad que participan como anfitriones.
-Todas las personas son bienvenidas.
-No es necesario inscribirse.**
+---
+title: "Sesiones de trabajo"
+description: |
+    Participa en nuestras reuniones de co-trabajo, socialización y horas de oficina los primeros martes de cada mes.
+    Organizado por la Asistente de la Comunidad de rOpenSci [Steffi LaZerte](/author/steffi-lazerte) y varias personas de la comunidad que participan como anfitriones.
+    Todas las personas son bienvenidas.
+    No es necesario inscribirse.
+---
 
 Nos reunimos durante dos horas, nos presentamos y trabajamos. Puedes elegir
 trabajar por tu cuenta o socializar eligiendo diferentes "salas" (Silenciosa o Ruidosa).

--- a/content/coworking/_index.md
+++ b/content/coworking/_index.md
@@ -1,11 +1,12 @@
-+++
-title = "Coworking"
-+++
+---
+title: "Coworking"
+description: |
+    Join us for social coworking & office hours monthly on first Tuesdays! 
+    Hosted by rOpenSci Community Assistant [Steffi LaZerte](/author/steffi-lazerte) and various community hosts. 
+    Everyone welcome. 
+    No registration needed.
+---
 
-**Join us for social coworking & office hours monthly on first Tuesdays! 
-Hosted by rOpenSci Community Assistant [Steffi LaZerte](/author/steffi-lazerte) and various community hosts. 
-Everyone welcome. 
-No registration needed.**
 
 We meet for two hours, introduce ourselves and cowork. You can choose to 
 work on your own or socialize by choosing different 'rooms' (Quiet or Noisy). 

--- a/data/team/team.json
+++ b/data/team/team.json
@@ -85,7 +85,11 @@
    ],
    "leads": [
      "champions",
-     "multilingual-publishing"
+     "multilingual-publishing",
+     "commcalls"
+   ],
+   "participates": [
+      "blog"
    ],
    "mastodon": "https://fosstodon.org/@yabellini",
    "linkedin": "https://www.linkedin.com/in/yabellini",
@@ -141,6 +145,13 @@
    "roles": [
       "staff",
       "developer"
+   ],
+   "leads": [
+      "coworking"
+   ],
+   "participates": [
+      "blog",
+      "commcalls"
    ],
    "twitter": "steffilazerte",
    "mastodon": "https://fosstodon.org/@steffilazerte",

--- a/themes/ropensci/layouts/blog/list.html
+++ b/themes/ropensci/layouts/blog/list.html
@@ -80,6 +80,7 @@
         </div>
       </div>
       <div class="col-md-3 d-none d-md-block">
+      {{ partial "team/people" (dict "project" "blog" "Site" .Site )}}
       {{ partial "blogs/blog-aside" }}
       </div>
     </div>

--- a/themes/ropensci/layouts/commcalls/list.html
+++ b/themes/ropensci/layouts/commcalls/list.html
@@ -6,6 +6,11 @@
       <div class="col-md-8">
         <h1>{{ .Title }}</h1>
         </div>
+        <div class="col-md-4 mt-4">
+          <aside>
+          {{ partial "team/people" (dict "project" "commcalls" "Site" .Site )}}
+          </aside>
+        </div>
       </div>
     <div class="row">
       <div class="col-md-8">
@@ -13,7 +18,7 @@
         {{ .Content }}
         </div>
       </div>
-    <div class="col-md-4">
+    <div class="col-md-4 mt-4">
       <img class="commcalls" src="/images/commcalls-img.png" alt="" />
     </div>
     </div>

--- a/themes/ropensci/layouts/coworking/list.html
+++ b/themes/ropensci/layouts/coworking/list.html
@@ -2,9 +2,17 @@
 <section class="section section-community-calls">
   <div class="container">
     <!-- Header text -->
-    <div class="row">
+    <div class="row mb-5">
       <div class="col-md-8">
         <h1>{{ .Title }}</h1>
+        <div class="pmt">
+        {{ .Params.description | markdownify }}
+        </div>
+        </div>
+        <div class="col-md-4 mt-4">
+          <aside>
+          {{ partial "team/people" (dict "project" "coworking" "Site" .Site )}}
+          </aside>
         </div>
       </div>
     <div class="row">


### PR DESCRIPTION
I must say I don't really like where it is on the blog page, but we can't fit in earlier without overhauling the design which I don't want. So if you don't like it either and don't have another idea I'd suggest we don't add it to the blog page?

The result is nicer on the comm calls and coworking pages I think.