### PR TITLE
improve featured event design

### DIFF
--- a/content/commcalls/2025-09-29/index.md
+++ b/content/commcalls/2025-09-29/index.md
@@ -15,7 +15,6 @@ location: online
 country: "\U0001F310"
 attendees: Everyone is welcome!
 slug: r-multiverse
-featured: true
 notes: 
 outputs:
 - HTML

--- a/content/events/2025-09-09-coworking-2025-09.md
+++ b/content/events/2025-09-09-coworking-2025-09.md
@@ -1,5 +1,5 @@
 ---
-title: Social Coworking and Office Hours - Improving accessibility in your work
+title: Social Coworking and Office Hours -- Improving accessibility in your work
 dateStart: 2025-09-09T12:00:00 # UTC!!
 dateEnd: 2025-09-09T14:00:00 # UTC!!
 date: 2025-09-09T14:00:00 # UTC!! same as dateEnd

--- a/content/events/2025-10-07-coworking-2025-10.md
+++ b/content/events/2025-10-07-coworking-2025-10.md
@@ -9,6 +9,7 @@ location: 'online' # free text
 slug: 'coworking-2025-10'
 country: "🌐" # emoji
 ropensci: yes
+featured: true
 outputs:
   - HTML
   - Calendar

--- a/content/events/2025-10-07-coworking-2025-10.md
+++ b/content/events/2025-10-07-coworking-2025-10.md
@@ -8,8 +8,7 @@ coworking: true
 location: 'online' # free text
 slug: 'coworking-2025-10'
 country: "🌐" # emoji
-ropensci: yes
-featured: true
+ropensci: true
 outputs:
   - HTML
   - Calendar

--- a/themes/ropensci/i18n/en.toml
+++ b/themes/ropensci/i18n/en.toml
@@ -188,6 +188,9 @@
 [Community-calls]  
   other = 'Community calls'
   
+[Community-call]  
+  other = 'Community call'
+  
 [Coworking]  
   other = 'Coworking'
   
@@ -330,3 +333,6 @@
 
 [Language]
   other = 'Language'
+
+[Future-ropensci-events]
+  other = 'Future rOpenSci events'

--- a/themes/ropensci/i18n/es.toml
+++ b/themes/ropensci/i18n/es.toml
@@ -191,6 +191,9 @@
 
 [Community-calls]  
   other = 'Conversaciones con la comunidad'
+
+[Community-call]  
+  other = 'Conversacion con la comunidad'
   
 [Coworking]  
   other = 'Sesiones de trabajo'
@@ -332,4 +335,8 @@
 
 [Language]
   other = 'Idioma'
+
+[Future-ropensci-events]
+  other = 'Eventos futuros de rOpenSci'
+
 

--- a/themes/ropensci/layouts/_default/featured-card.html
+++ b/themes/ropensci/layouts/_default/featured-card.html
@@ -12,7 +12,7 @@
                 {{ end }}
                 </div>
                 <a href="{{ .Permalink }}" class="card-title"
-                  >{{ .Title | markdownify }}{{ if intersect (slice .Section) (slice "commcalls" "events") }} <em>({{ .Params.lang | default "English"}})</em> {{ end }}
+                  >{{ .Title | markdownify }}
                 </a>
 
                 <div class="d-flex justify-content-between card-user">

--- a/themes/ropensci/layouts/_default/featured-card.html
+++ b/themes/ropensci/layouts/_default/featured-card.html
@@ -12,9 +12,9 @@
                 {{ end }}
                 </div>
                 <a href="{{ .Permalink }}" class="card-title"
-                  >{{ .Title | markdownify }}
+                  >{{ .Title | markdownify }}{{ if intersect (slice .Section) (slice "commcalls" "events") }} <em>({{ .Params.lang | default "English"}})</em> {{ end }}
                 </a>
-                 
+
                 <div class="d-flex justify-content-between card-user">
                     <span class="card-user__name">
                     {{ with .Params.author }}

--- a/themes/ropensci/layouts/_default/featured-card.html
+++ b/themes/ropensci/layouts/_default/featured-card.html
@@ -12,7 +12,7 @@
                 {{ end }}
                 </div>
                 <a href="{{ .Permalink }}" class="card-title"
-                  >{{ .Title | markdownify }}
+                  >{{ if eq .Type "commcalls" }} {{ i18n "Community-call" }} {{ "--" | markdownify }} {{ end }}{{ .Title | markdownify }}
                 </a>
 
                 <div class="d-flex justify-content-between card-user">

--- a/themes/ropensci/layouts/events/list.html
+++ b/themes/ropensci/layouts/events/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 {{ $pages := (partial "calendar/future-events" (dict "Site" .Site)) }}
-{{ $featured := ( where $pages "Params.featured" true ) }}
-<section class="blog-hero">
+{{ $featured := ( union (union (where $pages "Params.featured" true) (where $pages "Params.ropensci" true )) (where $pages "Type" "commcalls") ) }}
+<section class="blog-hero">de
   <div class="container bg-cubes">
     <div class="row align-items-center blog-heading">
         <h1>{{ i18n "Future-ropensci-events" }}</h1>
@@ -9,7 +9,7 @@
 {{ if gt (len $featured) 0 }}
     <div class="blog-featured">
       <div class="row">
-           {{ range $featured.ByDate }}
+           {{ range first 2 $featured.ByDate }}
           {{ .Render "featured-card" }}
           {{ end }}
         </div>

--- a/themes/ropensci/layouts/events/list.html
+++ b/themes/ropensci/layouts/events/list.html
@@ -9,7 +9,7 @@
 {{ if gt (len $featured) 0 }}
     <div class="blog-featured">
       <div class="row">
-           {{ range first 1 $featured.ByDate.Reverse }}
+           {{ range $featured.ByDate.Reverse }}
           {{ .Render "featured-card" }}
           {{ end }}
         </div>

--- a/themes/ropensci/layouts/events/list.html
+++ b/themes/ropensci/layouts/events/list.html
@@ -1,20 +1,24 @@
 {{ define "main" }}
 {{ $pages := (partial "calendar/future-events" (dict "Site" .Site)) }}
 {{ $featured := ( where $pages "Params.featured" true ) }}
+<section class="blog-hero">
+  <div class="container bg-cubes">
+    <div class="row align-items-center blog-heading">
+        <h1>{{ i18n "Future-ropensci-events" }}</h1>
+      </div>
 {{ if gt (len $featured) 0 }}
-    <section class="section event-hero">
-      <div class="container bg-cubes">
-        <div class="row">
+    <div class="blog-featured">
+      <div class="row">
            {{ range first 1 $featured.ByDate.Reverse }}
-          {{ .Render "featured-event-card" }}
+          {{ .Render "featured-card" }}
           {{ end }}
         </div>
       </div>
-    </section>
-    <img class="divider" src="../images/svg/divider-rl.svg" alt="" />
 {{ end }}
 {{ partial "calendar/events" (dict "Site" .Site "Content" .Content "Tips" .Params.Tips )  }}
          
+  </div>
+</section>
 {{ $newsletterpartial := (partial "translate-path" (dict "name" "whole-page-fragments/newsletter" "language" .Language.Lang )) }}
 {{ partial $newsletterpartial (dict "Site" .Site "divider" "rl" )  }}
 {{ end }}

--- a/themes/ropensci/layouts/events/list.html
+++ b/themes/ropensci/layouts/events/list.html
@@ -9,7 +9,7 @@
 {{ if gt (len $featured) 0 }}
     <div class="blog-featured">
       <div class="row">
-           {{ range $featured.ByDate.Reverse }}
+           {{ range $featured.ByDate }}
           {{ .Render "featured-card" }}
           {{ end }}
         </div>

--- a/themes/ropensci/layouts/events/single.html
+++ b/themes/ropensci/layouts/events/single.html
@@ -8,7 +8,7 @@
           {{ (time .Params.dateStart) | time.In $tz | dateFormat "Monday" }} {{ (time .Params.dateStart) | time.In $tz |
             dateFormat ":date_medium" }} {{ (time .Params.dateStart) | time.In $tz | dateFormat "15:04" }} ({{ $tz }})
         </div>
-        <h1>{{ .Title }}</h1>
+        <h1>{{ .Title | markdownify }}</h1>
         <div class="event-detail-author">
           <p><span class="ml-1">
               {{ .Params.location }}, {{ .Params.country }} • {{ i18n "With" }} {{ with .Params.attendees }}{{ partial


### PR DESCRIPTION
Fix #1116 

The solution is to use what we use for featured blog posts.

The downside of _rendering_ the featured events is that the card uses the _language of the event_ not the language of the page from which it is rendered. However this was already a problem, and this PR fixes the look of the card not the way it is rendered.