### PR TITLE
Add detail about moving figures to precompile vignettes post

### DIFF
--- a/_deepl.yml
+++ b/_deepl.yml
@@ -1,0 +1,30 @@
+preferences:
+  - source: en
+    target: es
+    formality: less
+    glossary: "glosario"
+    yaml_fields: ["title"]
+  - source: en
+    target: pt-br
+    formality: less
+    yaml_fields: ["title", "description"]
+  - source: pt
+    target: en-us
+    formality: prefer_less
+    yaml_fields: ["title", "description"]
+  - source: es
+    target: en-us
+    formality: prefer_less
+    yaml_fields: ["title", "description"]
+
+
+languages:
+  - extension: es
+    target: es
+    source: es
+  - extension: ''
+    target: en-us
+    source: en
+  - extension: pt
+    target: pt-br
+    source: pt

--- a/content/author/eric-scott/_index.pt.md
+++ b/content/author/eric-scott/_index.pt.md
@@ -1,0 +1,8 @@
+---
+name: Eric Scott
+link: https://www.ericrscott.com/
+twitter: leafyericscott
+github: Aariq
+mastodon: https://fosstodon.org/@LeafyEricScott
+orcid: 0000-0002-7430-7879
+---

--- a/content/blog/2019-12-08-precalculate-vignettes/index.es.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.es.md
@@ -14,7 +14,6 @@ tags:
 params:
   doi: 10.59350/yscyn-6eb34
 ---
-
 Desde principios de este año [construimos automáticamente](/technotes/2019/06/07/ropensci-docs/) binarios y documentación pkgdown para [todos los paquetes de rOpenSci](https://docs.ropensci.org). Pero un problema que hemos encontrado es que algunos paquetes incluyen viñetas que requieren algunas herramientas/datos/credenciales especiales, que no están disponibles en los servidores de compilación genéricos.
 
 Este post explica cómo incluir esas viñetas y artículos en tu paquete.
@@ -47,14 +46,14 @@ En el [paquete jsonlite](https://github.com/jeroen/jsonlite/tree/v1.6/vignettes)
 
 Un inconveniente de este truco es que si el resultado de la viñeta incluye figuras, tienes que guardar las imágenes en la carpeta de viñetas. También es una buena idea nombrar explícitamente tus trozos knitr de rmarkdown, para que las imágenes tengan nombres de archivos sensatos.
 
-Nuestro paquete recientemente incorporado [eia](https://github.com/ropensci/eia/tree/master/vignettes) de Matt Leonawicz es un buen ejemplo. Este paquete proporciona un cliente R para la API de Datos Abiertos de la Administración de Información Energética de EEUU. La página de [documentación de eia](https://docs.ropensci.org/eia/articles/) se genera automáticamente para cada confirmación del [servidor de documentación de rOpenSci](https://ropensci.org/technotes/2019/06/07/ropensci-docs/) aunque el código de las viñetas requieran en realidad una clave API (que el servidor de documentos no tiene).
+Nuestro paquete recientemente incorporado [eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) de Matt Leonawicz es un buen ejemplo. Este paquete proporciona un cliente R para la API de Datos Abiertos de la Administración de Información Energética de EEUU. La página de [documentación de eia](https://docs.ropensci.org/eia/articles/) se genera automáticamente para cada confirmación del [servidor de documentación de rOpenSci](https://ropensci.org/technotes/2019/06/07/ropensci-docs/) aunque el código de las viñetas requieran en realidad una clave API (que el servidor de documentos no tiene).
 
 {{< figure alt="captura de pantalla"  src="W5NDdOA.png" link="https://docs.ropensci.org/ei">}}
 
-El sitio [directorio de viñetas eia](https://github.com/ropensci/eia/blob/master/vignettes/) contiene las `Rmd.orig` archivos de entrada y los `.Rmd` calculados previamente por el autor del paquete. Ten en cuenta también que el directorio de viñetas contiene un práctico script [precompilar.R](https://github.com/ropensci/eia/blob/master/vignettes/precompile.R) que facilita al autor del paquete la actualización local de las viñetas de salida.
+El sitio [directorio de viñetas eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) contiene las `Rmd.orig` archivos de entrada y los `.Rmd` calculados previamente por el autor del paquete. Ten en cuenta también que el directorio de viñetas contiene un práctico script [precompilar.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) que facilita al autor del paquete la actualización local de las viñetas de salida.
+
+También podrías guionizar el movimiento de las figuras de la viñeta al lugar correcto como el `jstor` paquete con su [precompilar.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
 
 ## No olvides actualizar
 
 El inconveniente de este enfoque es que los documentos ya no se actualizan automáticamente cuando cambia el paquete. Por lo tanto, sólo debes precompilar las viñetas y artículos que sean problemáticos, y tomar nota para volver a redactar la viñeta de vez en cuando, por ejemplo, antes de la publicación de un paquete. Añadir un [guión](https://github.com/ropensci/eia/blob/master/vignettes/precompile.R) a tus carpetas de viñetas que lo haga ser un recordatorio útil.
-
-

--- a/content/blog/2019-12-08-precalculate-vignettes/index.es.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.es.md
@@ -3,6 +3,7 @@ slug: precompute-vignettes
 title: Cómo precomputar viñetas de paquetes o artículos pkgdown
 date: '2019-12-08'
 author: Jeroen Ooms
+editor: Eric Scott
 translator: 
 - Juan Cruz Enrique
 topicid: 1893

--- a/content/blog/2019-12-08-precalculate-vignettes/index.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.md
@@ -51,7 +51,7 @@ Our recently onboarded package [eia](https://github.com/ropensci/eia/blob/95cd1e
 
 The [eia vignettes directory](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/) contains the `Rmd.orig` input files and the `.Rmd` files as pre-computed by the package author. Also note the vignettes directory contains a handy script [precompile.R](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) that makes it easy for the package author to refresh the output vignettes locally.
 
-You could also script the moving of vignette figures to the correct place as the `GeoLink` package does with it's [precompile.R script](https://github.com/SSA-Statistical-Team-Projects/GeoLink/blob/8ce01ac48f460d81064ec78c13d91ebff5947168/vignettes/preCompile.R)
+You could also script the moving of vignette figures to the correct place as the `jstor` package does with it's [precompile.R script](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R)
 
 ## Don't forget to update
 

--- a/content/blog/2019-12-08-precalculate-vignettes/index.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.md
@@ -51,7 +51,7 @@ Our recently onboarded package [eia](https://github.com/ropensci/eia/blob/95cd1e
 
 The [eia vignettes directory](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/) contains the `Rmd.orig` input files and the `.Rmd` files as pre-computed by the package author. Also note the vignettes directory contains a handy script [precompile.R](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) that makes it easy for the package author to refresh the output vignettes locally.
 
-You could also script the moving of vignette figures to the correct place as the `jstor` package does with it's [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
+You could also script the moving of vignette figures to the correct place as the `jstor` package does with its [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
 
 ## Don't forget to update
 

--- a/content/blog/2019-12-08-precalculate-vignettes/index.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.md
@@ -3,6 +3,7 @@ slug: precompute-vignettes
 title: How to precompute package vignettes or pkgdown articles
 date: '2019-12-08'
 author: Jeroen Ooms
+editor: Eric Scott
 topicid: 1893
 tags:
   - docs

--- a/content/blog/2019-12-08-precalculate-vignettes/index.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.md
@@ -51,7 +51,7 @@ Our recently onboarded package [eia](https://github.com/ropensci/eia/blob/95cd1e
 
 The [eia vignettes directory](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/) contains the `Rmd.orig` input files and the `.Rmd` files as pre-computed by the package author. Also note the vignettes directory contains a handy script [precompile.R](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) that makes it easy for the package author to refresh the output vignettes locally.
 
-You could also script the moving of vignette figures to the correct place as the `jstor` package does with it's [precompile.R script](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R)
+You could also script the moving of vignette figures to the correct place as the `jstor` package does with it's [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
 
 ## Don't forget to update
 

--- a/content/blog/2019-12-08-precalculate-vignettes/index.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.md
@@ -45,11 +45,13 @@ The [jsonlite package](https://github.com/jeroen/jsonlite/tree/v1.6/vignettes) s
 
 One gotcha with this trick is that if the vignette output includes figures, you need to store the images in the vignettes folder. It is also a good idea to explicitly name your rmarkdown knitr chunks, so that the images have sensible filenames.
 
-Our recently onboarded package [eia](https://github.com/ropensci/eia/tree/master/vignettes) by Matt Leonawicz is a good example. This package provides an R client for US Energy Information Administration Open Data API. The [eia documentation](https://docs.ropensci.org/eia/articles/) gets automatically generated for each commit on the [rOpenSci docs server](https://ropensci.org/technotes/2019/06/07/ropensci-docs/), even though the code in the vignettes actually requires an API key (which the docs server does not have).
+Our recently onboarded package [eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) by Matt Leonawicz is a good example. This package provides an R client for US Energy Information Administration Open Data API. The [eia documentation](https://docs.ropensci.org/eia/articles/) gets automatically generated for each commit on the [rOpenSci docs server](https://ropensci.org/technotes/2019/06/07/ropensci-docs/), even though the code in the vignettes actually requires an API key (which the docs server does not have).
 
 {{< figure alt="screenshot" src="W5NDdOA.png" link="https://docs.ropensci.org/ei">}}
 
-The [eia vignettes directory](https://github.com/ropensci/eia/blob/master/vignettes/) contains the `Rmd.orig` input files and the `.Rmd` files as pre-computed by the package author. Also note the vignettes directory contains a handy script [precompile.R](https://github.com/ropensci/eia/blob/master/vignettes/precompile.R) that makes it easy for the package author to refresh the output vignettes locally.
+The [eia vignettes directory](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/) contains the `Rmd.orig` input files and the `.Rmd` files as pre-computed by the package author. Also note the vignettes directory contains a handy script [precompile.R](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) that makes it easy for the package author to refresh the output vignettes locally.
+
+You could also script the moving of vignette figures to the correct place as the `GeoLink` package does with it's [precompile.R script](https://github.com/SSA-Statistical-Team-Projects/GeoLink/blob/8ce01ac48f460d81064ec78c13d91ebff5947168/vignettes/preCompile.R)
 
 ## Don't forget to update
 

--- a/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
@@ -13,7 +13,6 @@ translator: Beatriz Milz
 params:
   doi: '10.59350/hchzp-hy971'
 ---
-
 Desde o início deste ano, passamos a [compilar automaticamente](/technotes/2019/06/07/ropensci-docs/) os arquivos binários e a renderizar a documentação com pkgdown para [todos os pacotes da rOpenSci](https://docs.ropensci.org). Um problema que encontramos é que alguns pacotes incluem vinhetas (*vignettes*) que exigem algumas ferramentas, dados, credenciais especiais, que não estão disponíveis em servidores de compilação genéricos.
 
 Esta postagem explica como você pode incluir essas vinhetas e artigos em seu pacote .
@@ -46,14 +45,14 @@ Os [pacote jsonlite](https://github.com/jeroen/jsonlite/tree/v1.6/vignettes) mos
 
 Um problema com esse truque é que, se a saída da vinheta incluir figuras, você precisará armazenar as imagens na pasta de vinhetas. Também é uma boa ideia nomear explicitamente seus pedaços de rmarkdown knitr, para que as imagens tenham nomes de arquivo que façam sentido.
 
-Nosso pacote recentemente incorporado [eia](https://github.com/ropensci/eia/tree/master/vignettes) de Matt Leonawicz, é um bom exemplo. Esse pacote fornece um cliente R para a API de dados abertos da Administração de Informações sobre Energia dos EUA. A página de [documentação do pacote eia](https://docs.ropensci.org/eia/articles/) é gerada automaticamente para cada commit no [servidor de documentação da rOpenSci](https://ropensci.org/technotes/2019/06/07/ropensci-docs/), embora o código nas vinhetas realmente exija uma chave de API (que o servidor de documentação não tem).
+Nosso pacote recentemente incorporado [eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) de Matt Leonawicz, é um bom exemplo. Esse pacote fornece um cliente R para a API de dados abertos da Administração de Informações sobre Energia dos EUA. A página de [documentação do pacote eia](https://docs.ropensci.org/eia/articles/) é gerada automaticamente para cada commit no [servidor de documentação da rOpenSci](https://ropensci.org/technotes/2019/06/07/ropensci-docs/), embora o código nas vinhetas realmente exija uma chave de API (que o servidor de documentação não tem).
 
 {{< figure alt="captura de tela"  src="W5NDdOA.png" link="https://docs.ropensci.org/ei">}}
 
-O [diretório de vinhetas do eia](https://github.com/ropensci/eia/blob/master/vignettes/) contém os arquivos de entrada `Rmd.orig` e os arquivos `.Rmd` pré-computados pelo autor do pacote. Observe também que o diretório de vinhetas contém um script útil chamado [precompile.R](https://github.com/ropensci/eia/blob/master/vignettes/precompile.R) que facilita para o autor do pacote atualizar as vinhetas de saída localmente.
+O [diretório de vinhetas do eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) contém os arquivos de entrada `Rmd.orig` e os arquivos `.Rmd` pré-computados pelo autor do pacote. Observe também que o diretório de vinhetas contém um script útil chamado [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) que facilita para o autor do pacote atualizar as vinhetas de saída localmente.
+
+Você também pode criar um script para mover as figuras de vinheta para o local correto como o `jstor` faz com seu pacote [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
 
 ## Não se esqueça de atualizar
 
 A desvantagem dessa abordagem é que os documentos não são mais atualizados automaticamente quando o pacote é alterado. Portanto, você só deve pré-computar as vinhetas e os artigos que são problemáticos e fazer uma anotação para que a vinheta seja refeita ocasionalmente, por exemplo, antes do lançamento de um pacote. Adicionando um [script](https://github.com/ropensci/eia/blob/master/vignettes/precompile.R) às pastas de vinhetas para que você faça isso pode ser um lembrete útil.
-
-

--- a/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
@@ -3,6 +3,7 @@ slug: precompute-vignettes
 title: Como pré-computar vinhetas de pacotes ou de artigos do pkgdown
 date: '2019-12-08'
 author: Jeroen Ooms
+editor: Eric Scott
 topicid: 1893
 tags:
 - documentação

--- a/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
@@ -52,7 +52,7 @@ Nosso pacote recentemente incorporado [eia](https://github.com/ropensci/eia/blob
 
 O [diretório de vinhetas do eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) contém os arquivos de entrada `Rmd.orig` e os arquivos `.Rmd` pré-computados pelo autor do pacote. Observe também que o diretório de vinhetas contém um script útil chamado [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) que facilita para o autor do pacote atualizar as vinhetas de saída localmente.
 
-Você também pode criar um script para mover as figuras de vinheta para o local correto como o `jstor` faz com seu pacote [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
+Você também pode criar um script para mover as figuras de vinheta para o local correto como o `jstor` faz com o seu pacote [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
 
 ## Não se esqueça de atualizar
 

--- a/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
+++ b/content/blog/2019-12-08-precalculate-vignettes/index.pt.md
@@ -50,7 +50,7 @@ Nosso pacote recentemente incorporado [eia](https://github.com/ropensci/eia/blob
 
 {{< figure alt="captura de tela"  src="W5NDdOA.png" link="https://docs.ropensci.org/ei">}}
 
-O [diretório de vinhetas do eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) contém os arquivos de entrada `Rmd.orig` e os arquivos `.Rmd` pré-computados pelo autor do pacote. Observe também que o diretório de vinhetas contém um script útil chamado [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) que facilita para o autor do pacote atualizar as vinhetas de saída localmente.
+O [diretório de vinhetas do eia](https://github.com/ropensci/eia/blob/95cd1e10ebda4143fd4fe24cf5836b10fa757a31/vignettes/precompile.R) contém os arquivos de entrada `Rmd.orig` e os arquivos `.Rmd` pré-computados pelo(a) autor(a) do pacote. Observe também que o diretório de vinhetas contém um script útil chamado [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) que facilita para o(a) autor(a) do pacote atualizar as vinhetas de saída localmente.
 
 Você também pode criar um script para mover as figuras de vinheta para o local correto como o `jstor` faz com o seu pacote [precompile.R](https://github.com/ropensci/jstor/blob/de60013deed4a129617a9ead25a642145c2190a6/vignettes/precompile.R) script.
 


### PR DESCRIPTION
Closes #1263.  I replaced the github links to `eia` vignettes and precompile.R with permalinks from the point in time @maelle  mentioned [here](https://github.com/ropensci/roweb3/issues/1263#issuecomment-4045049490).  I added a short sentence and permalink to `jstor`'s `precompile.R` script which has code to move the generated figures to the correct place.  I didn't link the the one from my package because I got the idea from searching GitHub for path:"vignettes/precompile.R" and this is one of the ropensci packages that did this.