### PR TITLE
Adjust to new help wanted issues file format

### DIFF
--- a/themes/ropensci/layouts/help-wanted/list.html
+++ b/themes/ropensci/layouts/help-wanted/list.html
@@ -17,7 +17,7 @@
                 <div class="d-flex flex-wrap align-items-center">
                   <a href="{{ .issue_url }}" class="case-title mr-2">{{ .title }}</a>
                   
-{{ if in .labels_first }} Good First Issue!{{ end }}
+{{ if .labels_first }} Good First Issue!{{ end }}
                 </div>
                 <p class="mt-2 case-text">
                <a href='https://github.com/{{ .labels_github }}'>{{ .labels_name }}</a>
@@ -52,7 +52,7 @@
     <td><a href="https://docs.ropensci.org/{{ .package }}">{{ .package }}</a> </td>
     <td>{{ dateFormat "2006-01-02" .opened }} </td>
     <td><a href='https://github.com/{{ .labels_github }}'>{{ .labels_name }}</a></td>
-    <td>{{ if in .labels_first }} yes {{ else }} no {{ end }}</td>
+    <td>{{ if .labels_first }} yes {{ else }} no {{ end }}</td>
   </tr>
       {{ end }} 
       </tbody>

--- a/themes/ropensci/layouts/help-wanted/list.html
+++ b/themes/ropensci/layouts/help-wanted/list.html
@@ -9,7 +9,7 @@
           </div>
         </div>
 <div class="row case-cards mt-5">
-  {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues.json") | unmarshal }}
+  {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues2.json") | unmarshal }}
          {{ range (first 3 (shuffle $issues) ) }}
           <div class="col-md-4">
             <div class="case-card">

--- a/themes/ropensci/layouts/help-wanted/list.html
+++ b/themes/ropensci/layouts/help-wanted/list.html
@@ -9,7 +9,7 @@
           </div>
         </div>
 <div class="row case-cards mt-5">
-  {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues2.json") | unmarshal }}
+  {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues.json") | unmarshal }}
          {{ range (first 3 (shuffle $issues) ) }}
           <div class="col-md-4">
             <div class="case-card">

--- a/themes/ropensci/layouts/help-wanted/list.html
+++ b/themes/ropensci/layouts/help-wanted/list.html
@@ -1,70 +1,68 @@
 {{ define "main" }}
-<section class="section section-generic">
-  <div class="container">
-    <!-- Header text -->
-    <div class="row">
-      <div class="col-md-8">
-        <h1>{{ .Title | markdownify }}</h1>
-        {{ .Content | markdownify }}
-      </div>
-    </div>
-    <div class="row case-cards mt-5">
-      {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues2.json") | unmarshal }}
-      {{ range (first 3 (shuffle $issues) ) }}
-      <div class="col-md-4">
-        <div class="case-card">
-          <div class="case-card-body">
-            <div class="d-flex flex-wrap align-items-center">
-              <a href="{{ .url }}" class="case-title mr-2">{{ .title }}</a>
-
-              {{ if in .labels_first }} Good First Issue!{{ end }}
-            </div>
-            <p class="mt-2 case-text">
-              <a href='https://github.com/{{ .username }}'>{{ .labels_name }}</a>
-            </p>
-            <p class="mt-2 case-text">
-              Opened on {{ dateFormat "2006-01-02" .opened }}.
-            </p>
+ <section class="section section-generic">
+      <div class="container">
+        <!-- Header text -->
+        <div class="row">
+          <div class="col-md-8">
+            <h1>{{ .Title | markdownify }}</h1>
+            {{ .Content | markdownify }}
           </div>
         </div>
-      </div>
-      {{ end }}
-
-
-    </div>
-
-    <div class="row case-cards mt-5">
+<div class="row case-cards mt-5">
+  {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues.json") | unmarshal }}
+         {{ range (first 3 (shuffle $issues) ) }}
+          <div class="col-md-4">
+            <div class="case-card">
+              <div class="case-card-body">
+                <div class="d-flex flex-wrap align-items-center">
+                  <a href="{{ .issue_url }}" class="case-title mr-2">{{ .title }}</a>
+                  
+{{ if in .labels_first }} Good First Issue!{{ end }}
+                </div>
+                <p class="mt-2 case-text">
+               <a href='https://github.com/{{ .labels_github }}'>{{ .labels_name }}</a>
+                </p>
+                                <p class="mt-2 case-text">
+               Opened on {{ dateFormat "2006-01-02" .opened }}.
+                </p>
+              </div>
+            </div>
+          </div>
+          {{ end }}
+          
+        
+        </div>
+        
+        <div class="row case-cards mt-5">
       <table id="usecases" class="display" width="100%">
         <thead>
           <tr>
-            <th>Issue</th>
-            <th>Package</th>
-            <th>Date Opened</th>
-            <th>Issue Author</th>
-            <th>Good First Issue?</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{ range $issues }}
-          <tr>
-
-            <td><a href="{{ .url }}">{{ .title }}</a></td>
-            <td><a href="https://docs.ropensci.org/{{ .package }}">{{ .package }}</a> </td>
-            <td>{{ dateFormat "2006-01-02" .opened }} </td>
-            <td><a href='https://github.com/{{ .labels_github }}'>{{ .labels_name }}</a></td>
-            <td>{{ if .labels_first }} yes {{else }} no {{ end }}</td>
-          </tr>
-          {{ end }}
-        </tbody>
+    <th>Issue</th>
+    <th>Package</th>
+    <th>Date Opened</th>
+    <th>Issue Author</th>
+    <th>Good First Issue?</th>
+  </tr>
+  </thead>
+      <tbody>
+      {{ range $issues }}
+   <tr>
+     
+    <td><a href="{{ .issue_url }}">{{ .title }}</a></td>
+    <td><a href="https://docs.ropensci.org/{{ .package }}">{{ .package }}</a> </td>
+    <td>{{ dateFormat "2006-01-02" .opened }} </td>
+    <td><a href='https://github.com/{{ .labels_github }}'>{{ .labels_name }}</a></td>
+    <td>{{ if in .labels_first }} yes {{ else }} no {{ end }}</td>
+  </tr>
+      {{ end }} 
+      </tbody>
       </table>
-    </div>
-    {{ partial "datatables/scripts" ( dict "id" "usecases" "col" 2 "order" "desc" ) }}
-
-</section>
-{{ $volunteerpartial := (partial "translate-path" (dict "name" "whole-page-fragments/volunteer" "language"
-.Language.Lang )) }}
-{{ partial $volunteerpartial (dict "divider" "rl" "Site" .Site ) }}
-{{ $newsletterpartial := (partial "translate-path" (dict "name" "whole-page-fragments/newsletter" "language"
-.Language.Lang )) }}
-{{ partial $newsletterpartial (dict "Site" .Site "divider" "lr" ) }}
+        </div>
+{{ partial "datatables/scripts" ( dict "id" "usecases" "col" 2 "order" "desc" )  }}
+       
+    </section>
+{{ $volunteerpartial := (partial "translate-path" (dict "name" "whole-page-fragments/volunteer" "language" .Language.Lang )) }}
+{{ partial $volunteerpartial  (dict "divider" "rl" "Site" .Site ) }}
+{{ $newsletterpartial := (partial "translate-path" (dict "name" "whole-page-fragments/newsletter" "language" .Language.Lang )) }}
+{{ partial $newsletterpartial (dict "Site" .Site "divider" "lr" )  }}
 {{ end }}

--- a/themes/ropensci/layouts/help-wanted/list.html
+++ b/themes/ropensci/layouts/help-wanted/list.html
@@ -1,68 +1,70 @@
 {{ define "main" }}
- <section class="section section-generic">
-      <div class="container">
-        <!-- Header text -->
-        <div class="row">
-          <div class="col-md-8">
-            <h1>{{ .Title | markdownify }}</h1>
-            {{ .Content | markdownify }}
-          </div>
-        </div>
-<div class="row case-cards mt-5">
-  {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues.json") | unmarshal }}
-         {{ range (first 3 (shuffle $issues) ) }}
-          <div class="col-md-4">
-            <div class="case-card">
-              <div class="case-card-body">
-                <div class="d-flex flex-wrap align-items-center">
-                  <a href="{{ .url }}" class="case-title mr-2">{{ .title }}</a>
-                  
-{{ if in .labels "good first issue" }} Good First Issue!{{ end }}
-                </div>
-                <p class="mt-2 case-text">
-               {{ if ne .author "" }} <a href='https://github.com/{{ .username }}'>{{ .author }}</a>{{ else }}<a href='https://github.com/{{ .username }}'>{{ .username }}</a>{{ end }}
-                </p>
-                                <p class="mt-2 case-text">
-               Opened on {{ dateFormat "2006-01-02" .opened }}.
-                </p>
-              </div>
+<section class="section section-generic">
+  <div class="container">
+    <!-- Header text -->
+    <div class="row">
+      <div class="col-md-8">
+        <h1>{{ .Title | markdownify }}</h1>
+        {{ .Content | markdownify }}
+      </div>
+    </div>
+    <div class="row case-cards mt-5">
+      {{ $issues := (resources.GetRemote "https://ropensci-help-wanted.netlify.app/issues2.json") | unmarshal }}
+      {{ range (first 3 (shuffle $issues) ) }}
+      <div class="col-md-4">
+        <div class="case-card">
+          <div class="case-card-body">
+            <div class="d-flex flex-wrap align-items-center">
+              <a href="{{ .url }}" class="case-title mr-2">{{ .title }}</a>
+
+              {{ if in .labels_first }} Good First Issue!{{ end }}
             </div>
+            <p class="mt-2 case-text">
+              <a href='https://github.com/{{ .username }}'>{{ .labels_name }}</a>
+            </p>
+            <p class="mt-2 case-text">
+              Opened on {{ dateFormat "2006-01-02" .opened }}.
+            </p>
           </div>
-          {{ end }}
-          
-        
         </div>
-        
-        <div class="row case-cards mt-5">
+      </div>
+      {{ end }}
+
+
+    </div>
+
+    <div class="row case-cards mt-5">
       <table id="usecases" class="display" width="100%">
         <thead>
           <tr>
-    <th>Issue</th>
-    <th>Package</th>
-    <th>Date Opened</th>
-    <th>Issue Author</th>
-    <th>Good First Issue?</th>
-  </tr>
-  </thead>
-      <tbody>
-      {{ range $issues }}
-   <tr>
-     
-    <td><a href="{{ .url }}">{{ .title }}</a></td>
-    <td><a href="https://docs.ropensci.org/{{ .package }}">{{ .package }}</a> </td>
-    <td>{{ dateFormat "2006-01-02" .opened }} </td>
-    <td>{{ if ne .author "" }} <a href='https://github.com/{{ .username }}'>{{ .author }}</a>{{ else }}<a href='https://github.com/{{ .username }}'>{{ .username }}</a>{{ end }}</td>
-    <td>{{ if in .labels "good first issue" }} yes {{else }} no{{ end }}</td>
-  </tr>
-      {{ end }} 
-      </tbody>
+            <th>Issue</th>
+            <th>Package</th>
+            <th>Date Opened</th>
+            <th>Issue Author</th>
+            <th>Good First Issue?</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{ range $issues }}
+          <tr>
+
+            <td><a href="{{ .url }}">{{ .title }}</a></td>
+            <td><a href="https://docs.ropensci.org/{{ .package }}">{{ .package }}</a> </td>
+            <td>{{ dateFormat "2006-01-02" .opened }} </td>
+            <td><a href='https://github.com/{{ .labels_github }}'>{{ .labels_name }}</a></td>
+            <td>{{ if .labels_first }} yes {{else }} no {{ end }}</td>
+          </tr>
+          {{ end }}
+        </tbody>
       </table>
-        </div>
-{{ partial "datatables/scripts" ( dict "id" "usecases" "col" 2 "order" "desc" )  }}
-       
-    </section>
-{{ $volunteerpartial := (partial "translate-path" (dict "name" "whole-page-fragments/volunteer" "language" .Language.Lang )) }}
-{{ partial $volunteerpartial  (dict "divider" "rl" "Site" .Site ) }}
-{{ $newsletterpartial := (partial "translate-path" (dict "name" "whole-page-fragments/newsletter" "language" .Language.Lang )) }}
-{{ partial $newsletterpartial (dict "Site" .Site "divider" "lr" )  }}
+    </div>
+    {{ partial "datatables/scripts" ( dict "id" "usecases" "col" 2 "order" "desc" ) }}
+
+</section>
+{{ $volunteerpartial := (partial "translate-path" (dict "name" "whole-page-fragments/volunteer" "language"
+.Language.Lang )) }}
+{{ partial $volunteerpartial (dict "divider" "rl" "Site" .Site ) }}
+{{ $newsletterpartial := (partial "translate-path" (dict "name" "whole-page-fragments/newsletter" "language"
+.Language.Lang )) }}
+{{ partial $newsletterpartial (dict "Site" .Site "divider" "lr" ) }}
 {{ end }}


### PR DESCRIPTION
I've made updates to the help wanted script which results in a more understandable issues.json, but with different column names.

This PR adjusts the column names used by roweb and tests this with issues2.json.

Before merging:
- [x] Change issues2.json to issues.json in the help-wanted repo
- [x] Change issues2.json to issues.json in this PR